### PR TITLE
Add bulk resources editor

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -34,6 +34,11 @@
         <button id="loadSaPresetBtn" class="rounded-xl px-3 py-2 bg-white border border-amber-400 text-amber-700 focus-ring" title="Load SA Equal Before the Law?">
           Load SA “Equal Before the Law?”
         </button>
+        <button id="bulkResBtn"
+          class="rounded-xl px-3 py-2 bg-white border border-sky-400 text-sky-700 focus-ring"
+          title="Bulk update Resources">
+          Update Resources
+        </button>
       </div>
     </div>
   </header>
@@ -623,6 +628,77 @@ function bindListEditors(root){
   });
 }
 
+// --- Bulk Resources Editor ---
+function openResourcesEditor(){
+  // remove any existing overlay
+  var existing = document.getElementById('resEditorOverlay');
+  if (existing) existing.remove();
+
+  // build overlay
+  var overlay = document.createElement('div');
+  overlay.id = 'resEditorOverlay';
+  overlay.className = 'fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4';
+
+  // textarea content from plan.resources
+  var initial = (plan.resources || []).join('\n');
+
+  overlay.innerHTML = ''
+    + '<div role="dialog" aria-modal="true" aria-labelledby="resEditorTitle"'
+    + ' class="max-w-2xl w-full bg-white rounded-2xl shadow-2xl border border-slate-200">'
+    + '  <div class="p-4 border-b border-slate-200 flex items-center justify-between">'
+    + '    <h3 id="resEditorTitle" class="text-lg font-semibold">Update Resources</h3>'
+    + '    <button type="button" data-cancel'
+    + '      class="px-2 py-1 text-slate-600 hover:text-slate-900" aria-label="Close">✕</button>'
+    + '  </div>'
+    + '  <div class="p-4">'
+    + '    <p class="text-sm text-slate-600 mb-2">One resource per line. Titles, links or short descriptions.</p>'
+    + '    <textarea id="resEditorTextarea"'
+    + '      class="w-full h-64 rounded-xl border border-slate-300 px-3 py-2 font-mono text-sm"'
+    + '      placeholder="e.g. PEO: Australian Constitution resources&#10;AEC: Referendums – double majority&#10;Local council website (civic participation examples)"></textarea>'
+    + '  </div>'
+    + '  <div class="p-4 border-t border-slate-200 flex items-center justify-end gap-2">'
+    + '    <button type="button" data-cancel'
+    + '      class="rounded-xl px-3 py-2 border border-slate-300 bg-white">Cancel</button>'
+    + '    <button type="button" data-save'
+    + '      class="rounded-xl px-3 py-2 bg-slate-900 text-white">Save</button>'
+    + '  </div>'
+    + '</div>';
+
+  document.body.appendChild(overlay);
+
+  // load initial text
+  var ta = overlay.querySelector('#resEditorTextarea');
+  ta.value = initial;
+
+  // close helpers
+  function close(){ overlay.remove(); }
+  function onEsc(e){ if(e.key === 'Escape'){ close(); document.removeEventListener('keydown', onEsc); } }
+
+  // clicks
+  overlay.addEventListener('click', function(e){
+    if (e.target === overlay || e.target.closest('[data-cancel]')) { close(); }
+  });
+
+  // save
+  overlay.querySelector('[data-save]').addEventListener('click', function(){
+    var lines = ta.value.split('\n')
+      .map(function(s){ return s.trim(); })
+      .filter(function(s){ return s.length > 0; });
+
+    plan.resources = lines;
+    saveState();
+    render();
+    notify('Resources updated (' + lines.length + ' item' + (lines.length===1?'':'s') + ')');
+    close();
+  });
+
+  // escape key
+  document.addEventListener('keydown', onEsc);
+
+  // focus textarea
+  setTimeout(function(){ ta.focus(); ta.selectionStart = ta.value.length; ta.selectionEnd = ta.value.length; }, 0);
+}
+
 // Events
 $('#printBtn').addEventListener('click', function(){ window.print(); });
 $('#exportBtn').addEventListener('click', function(){
@@ -645,6 +721,7 @@ $('#curriculumToggle').addEventListener('click', function(e){
   var b=e.target.closest('button'); if(!b) return; plan.curriculumView=b.dataset.mode; saveState(); render();
 });
 $('#tabs').addEventListener('click', function(e){ var b=e.target.closest('button'); if(!b) return; selectTab(b.dataset.tab); });
+document.getElementById('bulkResBtn').addEventListener('click', openResourcesEditor);
 $('#loadSaPresetBtn').addEventListener('click', function(){
   var ok = safeConfirm('Replace the current plan with the SA "Equal Before the Law?" preset?');
   if(!ok) return;


### PR DESCRIPTION
## Summary
- add an Update Resources action alongside the SA preset control in the header
- implement a modal-based bulk resources editor that syncs edits back to the plan data and rerenders the view

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68c8c0abc84883248864fc7ff0d64f9f