### PR TITLE
Add PEO Year 9 activities explorer

### DIFF
--- a/css/peo-y9.css
+++ b/css/peo-y9.css
@@ -1,0 +1,488 @@
+.skip-link {
+  position: absolute;
+  top: -999px;
+  left: 0.75rem;
+  padding: 0.75rem 1rem;
+  background-color: #0f172a;
+  color: #fff;
+  z-index: 1000;
+  border-radius: 0.75rem;
+  text-decoration: none;
+  box-shadow: 0 10px 25px -15px rgba(15, 23, 42, 0.6);
+}
+
+.skip-link:focus {
+  top: 0.75rem;
+}
+
+.section {
+  background-color: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(8px);
+  border-radius: 1.25rem;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 18px 45px -30px rgba(15, 23, 42, 0.45);
+  padding: 1.75rem 1.5rem 2rem;
+}
+
+.section h2 {
+  font-size: clamp(1.5rem, 2vw, 1.85rem);
+  font-weight: 700;
+  color: #0f172a;
+  margin-bottom: 1.5rem;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.controls input[type="search"],
+.controls select {
+  border: 1px solid #cbd5f5;
+  border-radius: 0.75rem;
+  padding: 0.55rem 0.9rem;
+  min-width: 12rem;
+  background-color: #fff;
+  color: #0f172a;
+  box-shadow: inset 0 1px 2px rgba(148, 163, 184, 0.2);
+}
+
+.controls input[type="search"]:focus-visible,
+.controls select:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.4);
+  outline-offset: 2px;
+}
+
+.controls button {
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5f5;
+  background-color: #f8fafc;
+  padding: 0.55rem 1rem;
+  font-weight: 600;
+  color: #1e293b;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.controls button:hover,
+.controls button:focus-visible {
+  background-color: #e0f2fe;
+}
+
+.controls button:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.4);
+  outline-offset: 2px;
+}
+
+.controls button[aria-pressed="true"],
+.controls button.is-on {
+  background-color: #0f172a;
+  color: #fff;
+  border-color: #0f172a;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.activity-card {
+  border-radius: 1rem;
+  border: 1px solid #e2e8f0;
+  background: linear-gradient(145deg, rgba(248, 250, 252, 0.92), rgba(241, 245, 249, 0.9));
+  box-shadow: 0 20px 35px -28px rgba(15, 23, 42, 0.55);
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.activity-card.favorited {
+  border-color: #f59e0b;
+  box-shadow: 0 18px 38px -28px rgba(217, 119, 6, 0.6);
+}
+
+.activity-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 1rem 1rem 0.5rem;
+}
+
+.activity-toggle {
+  flex: 1 1 auto;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  padding: 0;
+}
+
+.activity-toggle:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.8);
+  outline-offset: 3px;
+}
+
+.activity-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #0f172a;
+  display: block;
+}
+
+.activity-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.6rem;
+  font-size: 0.85rem;
+  color: #475569;
+  align-items: center;
+}
+
+.topic-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #fff;
+  letter-spacing: 0.01em;
+}
+
+.topic-chip .topic-label {
+  display: inline-block;
+}
+
+.type-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+  background-color: #e2e8f0;
+  color: #1e293b;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.duration-pill {
+  background-color: #cbd5f5;
+  color: #1e293b;
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.favorite-btn {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  color: #fbbf24;
+  font-size: 0.95rem;
+  font-weight: 700;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.favorite-flag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background-color: rgba(251, 191, 36, 0.18);
+  color: #b45309;
+  border-radius: 999px;
+  padding: 0.15rem 0.55rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.grouping-label {
+  font-size: 0.85rem;
+  color: #475569;
+  font-weight: 600;
+}
+
+.favorite-btn .star {
+  font-size: 1.1rem;
+}
+
+.favorite-btn:hover,
+.favorite-btn:focus-visible {
+  background-color: rgba(251, 191, 36, 0.16);
+}
+
+.favorite-btn[aria-pressed="true"] {
+  color: #b45309;
+}
+
+.favorite-btn:focus-visible {
+  outline: 3px solid rgba(234, 179, 8, 0.6);
+  outline-offset: 2px;
+}
+
+.activity-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1rem 0.75rem;
+  gap: 0.5rem;
+}
+
+.activity-actions label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: #334155;
+  margin-left: auto;
+}
+
+.activity-body {
+  padding: 0 1rem 1.25rem;
+  font-size: 0.95rem;
+  color: #1e293b;
+}
+
+.activity-body > * + * {
+  margin-top: 1rem;
+}
+
+.activity-body h3 {
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin-bottom: 0.45rem;
+  color: #0f172a;
+}
+
+.activity-body ul,
+.activity-body ol {
+  padding-left: 1.25rem;
+}
+
+.activity-body li + li {
+  margin-top: 0.35rem;
+}
+
+.teacher-tip {
+  border-left: 3px solid #0f172a;
+  background-color: rgba(30, 64, 175, 0.08);
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.teacher-tip strong {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+}
+
+.links-list {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.links-list a {
+  color: #1d4ed8;
+  text-decoration: underline;
+  font-weight: 600;
+}
+
+.links-list a:focus-visible {
+  outline: 3px solid rgba(29, 78, 216, 0.5);
+  outline-offset: 2px;
+}
+
+.links-list a .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.links-list a .outbound-icon {
+  font-size: 0.8rem;
+  margin-left: 0.3rem;
+}
+
+.empty-state {
+  padding: 2rem;
+  border-radius: 1rem;
+  background-color: rgba(226, 232, 240, 0.6);
+  color: #475569;
+  text-align: center;
+  font-weight: 600;
+}
+
+.peo-print-area {
+  display: none;
+}
+
+body.peo-printing .peo-print-area {
+  display: block;
+  background: #fff;
+  color: #0f172a;
+  padding: 2rem;
+}
+
+body.peo-printing header,
+body.peo-printing footer,
+body.peo-printing main {
+  display: none !important;
+}
+
+body.peo-printing .peo-print-area {
+  font-size: 0.95rem;
+}
+
+body.peo-printing .peo-print-area h1 {
+  font-size: 1.5rem;
+  margin-bottom: 0.25rem;
+}
+
+body.peo-printing .peo-print-area .print-meta {
+  margin-bottom: 1.5rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+body.peo-printing .peo-print-activity {
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #cbd5f5;
+  page-break-inside: avoid;
+}
+
+body.peo-printing .peo-print-activity h2 {
+  font-size: 1.15rem;
+  margin-bottom: 0.5rem;
+}
+
+@media (max-width: 640px) {
+  .controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .controls input[type="search"],
+  .controls select,
+  .controls button {
+    width: 100%;
+  }
+
+  .activity-actions {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .activity-actions label {
+    margin-left: 0;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .section {
+    background-color: rgba(15, 23, 42, 0.85);
+    border-color: rgba(148, 163, 184, 0.4);
+    color: #f8fafc;
+  }
+
+  .section h2 {
+    color: #f8fafc;
+  }
+
+  .controls input[type="search"],
+  .controls select {
+    background-color: rgba(15, 23, 42, 0.85);
+    border-color: rgba(148, 163, 184, 0.45);
+    color: #f8fafc;
+  }
+
+  .controls button {
+    background-color: rgba(30, 41, 59, 0.9);
+    border-color: rgba(148, 163, 184, 0.4);
+    color: #e2e8f0;
+  }
+
+  .controls button:hover,
+  .controls button:focus-visible {
+    background-color: rgba(14, 116, 144, 0.35);
+  }
+
+  .activity-card {
+    background: linear-gradient(145deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.95));
+    border-color: rgba(100, 116, 139, 0.45);
+  }
+
+  .activity-card.favorited {
+    border-color: rgba(251, 191, 36, 0.8);
+  }
+
+  .activity-title,
+  .activity-body,
+  .activity-actions label {
+    color: #f8fafc;
+  }
+
+  .activity-body h3 {
+    color: #f8fafc;
+  }
+
+  .grouping-label {
+    color: #e2e8f0;
+  }
+
+  .duration-pill {
+    background-color: rgba(148, 163, 184, 0.35);
+    color: #f8fafc;
+  }
+
+  .type-chip {
+    background-color: rgba(148, 163, 184, 0.35);
+    color: #e2e8f0;
+  }
+
+  .teacher-tip {
+    background-color: rgba(56, 189, 248, 0.2);
+    border-left-color: rgba(56, 189, 248, 0.8);
+  }
+
+  .links-list a {
+    color: #93c5fd;
+  }
+
+  .favorite-flag {
+    background-color: rgba(251, 191, 36, 0.3);
+    color: #fde68a;
+  }
+
+  body.peo-printing {
+    background: #fff;
+    color: #0f172a;
+  }
+}
+
+@media print {
+  body.peo-printing .peo-print-area {
+    display: block !important;
+  }
+}

--- a/data/peo-y9-activities.json
+++ b/data/peo-y9-activities.json
@@ -1,0 +1,182 @@
+{
+  "topics": [
+    {
+      "id": "media-literacy",
+      "title": "Media Literacy",
+      "color": "#2463EB",
+      "activities": [
+        {
+          "id": "news-diet-challenge",
+          "title": "News Diet Challenge",
+          "type": ["discussion", "inquiry"],
+          "duration": "30–45 min",
+          "grouping": "Pairs → Whole class",
+          "objectives": [
+            "Differentiate facts, opinions and bias in news sources",
+            "Reflect on personal news consumption habits"
+          ],
+          "materials": [
+            "Student devices or printed articles",
+            "Reflection sheet (PDF/Doc link)"
+          ],
+          "steps": [
+            "Students list sources they used in the past 48 hours.",
+            "Classify each item: fact / opinion / mixed; identify any bias.",
+            "Pairs swap lists and critique balance (domestic/world, sources, formats).",
+            "Whole-class share: what changed in their ‘news diet’ thinking?"
+          ],
+          "assessment": "Exit ticket: one change they’ll make to improve balance and reliability.",
+          "links": [
+            {"label": "PEO – Year 9 Units (Media)", "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"}
+          ],
+          "tags": ["media", "bias", "source-analysis", "critical-thinking"]
+        }
+      ]
+    },
+    {
+      "id": "political-parties",
+      "title": "Political Parties",
+      "color": "#16A34A",
+      "activities": [
+        {
+          "id": "frayer-model",
+          "title": "Frayer Model: Party Ideology",
+          "type": ["graphic-organiser", "research"],
+          "duration": "40–60 min",
+          "grouping": "Small groups",
+          "objectives": [
+            "Define and exemplify key party ideology terms",
+            "Compare similarities and differences across parties"
+          ],
+          "materials": ["Frayer template", "Party websites / fact sheets"],
+          "steps": [
+            "Assign each group a party/ideology term.",
+            "Complete Frayer (definition, characteristics, examples, non-examples).",
+            "Gallery walk; add ‘two stars and a wish’ feedback to each poster."
+          ],
+          "assessment": "Collect Frayers; assess clarity/accuracy and use of evidence.",
+          "links": [
+            {"label": "PEO – Parties & Government", "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"}
+          ],
+          "tags": ["parties", "ideology", "compare-contrast"]
+        }
+      ]
+    },
+    {
+      "id": "parliament-law-making",
+      "title": "Parliament & Law-Making",
+      "color": "#DC2626",
+      "activities": [
+        {
+          "id": "bill-simulation",
+          "title": "How a Bill Becomes Law – Simulation",
+          "type": ["simulation", "role-play"],
+          "duration": "60–90 min",
+          "grouping": "Whole class roles",
+          "objectives": [
+            "Explain the stages of a bill in the federal Parliament",
+            "Experience debate, committee and voting processes"
+          ],
+          "materials": ["Role cards", "Bill summary handout", "Chamber layout"],
+          "steps": [
+            "Assign roles (Speaker/President, Government/Opposition, Crossbench, Clerks, Whips, Media).",
+            "First/second reading, debate, possible amendments.",
+            "Optional committee stage; third reading; Senate repeat; Royal Assent.",
+            "Debrief: link steps to real-world examples."
+          ],
+          "assessment": "Quick-write: which stage most influences outcomes and why?",
+          "links": [
+            {"label": "PEO – Making Laws", "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"}
+          ],
+          "tags": ["parliament", "bills", "procedure", "debate"]
+        }
+      ]
+    },
+    {
+      "id": "courts-justice",
+      "title": "Courts & Justice",
+      "color": "#7C3AED",
+      "activities": [
+        {
+          "id": "mock-hearing",
+          "title": "Courtroom Role-Play: How Courts Support Democracy",
+          "type": ["role-play", "case-study"],
+          "duration": "45–70 min",
+          "grouping": "Small groups → plenary",
+          "objectives": [
+            "Identify roles and processes in Australian courts",
+            "Explain rule of law and judicial independence"
+          ],
+          "materials": ["Case summary", "Role cards", "Verdict sheet"],
+          "steps": [
+            "Groups stage a short hearing with set roles.",
+            "Observers use a checklist (fairness, due process, evidence usage).",
+            "Compare outcomes across groups; discuss consistency and appeals."
+          ],
+          "assessment": "Checklist + reflection paragraph on fairness and due process.",
+          "links": [
+            {"label": "PEO – Courts & Justice", "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"}
+          ],
+          "tags": ["courts", "rule-of-law", "judicial-independence"]
+        }
+      ]
+    },
+    {
+      "id": "citizen-participation",
+      "title": "Citizen Participation",
+      "color": "#0EA5E9",
+      "activities": [
+        {
+          "id": "petition-plan",
+          "title": "Petition & Lobby Plan",
+          "type": ["civics-action", "planning"],
+          "duration": "50–70 min",
+          "grouping": "Teams",
+          "objectives": [
+            "Map an issue, stakeholders, and a lawful action pathway",
+            "Draft a persuasive petition and outreach plan"
+          ],
+          "materials": ["Stakeholder map template", "Petition template"],
+          "steps": [
+            "Choose a local issue; map stakeholders and decision-makers.",
+            "Draft petition text (clear ask, reasons, evidence).",
+            "Plan lawful outreach (meetings, letters, social media etiquette)."
+          ],
+          "assessment": "Submit a 1-page plan with SMART next steps.",
+          "links": [
+            {"label": "PEO – Participation", "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"}
+          ],
+          "tags": ["participation", "advocacy", "petitions"]
+        }
+      ]
+    },
+    {
+      "id": "assessment",
+      "title": "Assessment Options",
+      "color": "#F97316",
+      "activities": [
+        {
+          "id": "civics-inquiry-project",
+          "title": "Civics Inquiry: Local Issue Case Study",
+          "type": ["product", "presentation"],
+          "duration": "Multi-lesson",
+          "grouping": "Individual or pairs",
+          "objectives": [
+            "Investigate a civics issue and present evidence-based recommendations"
+          ],
+          "materials": ["Inquiry guide", "Rubric", "Presentation template"],
+          "steps": [
+            "Define a guiding question aligned to curriculum content.",
+            "Collect and evaluate sources (reliability, bias).",
+            "Present findings via report, video, podcast, or infographic."
+          ],
+          "assessment": "Rubric aligned to ACARA Year 9 Civics & Citizenship.",
+          "links": [
+            {"label": "PEO – Assessments", "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"}
+          ],
+          "tags": ["assessment", "inquiry", "communication"]
+        }
+      ]
+    }
+  ]
+}

--- a/index.htm
+++ b/index.htm
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Year 9 Civics & Citizenship – Unit Plan (Single HTML)</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/peo-y9.css" />
+  <script defer src="js/peo-y9.js"></script>
   <style>
     :root{ --ring: 219 14% 28%; }
     .focus-ring:focus{ outline: 2px solid hsl(var(--ring)); outline-offset: 2px; }
@@ -17,6 +19,7 @@
   </style>
 </head>
 <body class="min-h-screen bg-gradient-to-b from-slate-100 to-slate-200 text-slate-900">
+  <a class="skip-link" href="#mainContent">Skip to content</a>
   <!-- Top Bar -->
   <header class="sticky top-0 z-10 border-b border-slate-200 backdrop-blur bg-white/70">
     <div class="max-w-6xl mx-auto px-4 py-4 flex flex-wrap items-center gap-4 justify-between">
@@ -41,9 +44,18 @@
         </button>
       </div>
     </div>
+    <nav class="no-print border-t border-slate-200 bg-white/60">
+      <div class="max-w-6xl mx-auto px-4 py-2">
+        <ul class="flex flex-wrap items-center gap-3 text-sm font-semibold text-slate-700">
+          <li>
+            <a class="rounded-lg px-3 py-2 hover:bg-slate-100 focus-ring" href="#peo-y9">PEO Year 9 Activities</a>
+          </li>
+        </ul>
+      </div>
+    </nav>
   </header>
 
-  <main class="max-w-6xl mx-auto p-4 space-y-6">
+  <main id="mainContent" class="max-w-6xl mx-auto p-4 space-y-6">
     <!-- Unit Details Card -->
     <section class="bg-white/80 backdrop-blur rounded-2xl shadow p-5 border border-slate-200">
       <div class="flex items-start justify-between gap-4">
@@ -64,6 +76,23 @@
 
     <!-- Tab Panels -->
     <div id="panel" aria-live="polite"></div>
+
+    <section id="peo-y9" class="section">
+      <h2 tabindex="-1">PEO Year 9 Activities</h2>
+
+      <!-- Controls -->
+      <div class="controls">
+        <input id="searchActivities" type="search" placeholder="Search activities, tags, objectives…" aria-label="Search activities" />
+        <select id="filterTopic" aria-label="Filter by topic"></select>
+        <select id="filterType" aria-label="Filter by type"></select>
+        <button id="filterFavorites" aria-pressed="false">Favorites</button>
+        <button id="toggleTeacherMode" aria-pressed="false">Teacher Mode: Off</button>
+        <button id="printSelected">Print/Export Selected</button>
+      </div>
+
+      <!-- Rendered cards go here -->
+      <div id="activitiesGrid" class="grid"></div>
+    </section>
   </main>
 
   <footer class="max-w-6xl mx-auto px-4 py-8 text-xs text-slate-500">

--- a/js/peo-y9.js
+++ b/js/peo-y9.js
@@ -1,0 +1,672 @@
+(function(){
+  const section = document.getElementById('peo-y9');
+  if(!section){ return; }
+
+  const heading = section.querySelector('h2');
+  const searchInput = section.querySelector('#searchActivities');
+  const topicSelect = section.querySelector('#filterTopic');
+  const typeSelect = section.querySelector('#filterType');
+  const teacherModeBtn = section.querySelector('#toggleTeacherMode');
+  const printBtn = section.querySelector('#printSelected');
+  const favoritesBtn = section.querySelector('#filterFavorites');
+  const grid = section.querySelector('#activitiesGrid');
+
+  const STORAGE_KEYS = {
+    teacherMode: 'peoY9.teacherMode',
+    favorites: 'peoY9.favorites',
+    selected: 'peoY9.selected'
+  };
+
+  const teacherTips = {
+    'news-diet-challenge': 'Provide curated examples for students needing support and encourage an extension group to contrast public vs. commercial broadcasters.',
+    'frayer-model': 'Pre-teach key vocabulary for EAL/D students and offer a digital template for students who type faster than they write.',
+    'bill-simulation': 'Assign timekeeper and reflection roles so every student contributes; record debate snippets for formative feedback.',
+    'mock-hearing': 'Rotate students through observer and advocate roles across repeats to deepen understanding of due process.',
+    'petition-plan': 'Model a SMART goal together before release and have teacher check-ins on respectful communication strategies.',
+    'civics-inquiry-project': 'Conference midway to approve inquiry questions and suggest differentiation options for presentation formats.'
+  };
+
+  const state = {
+    topics: [],
+    activities: [],
+    topicFilter: 'all',
+    typeFilter: 'all',
+    searchTerm: '',
+    favoritesOnly: false,
+    teacherMode: getStoredBoolean(STORAGE_KEYS.teacherMode, false),
+    favorites: getStoredArray(STORAGE_KEYS.favorites),
+    selectedForPrint: getStoredArray(STORAGE_KEYS.selected)
+  };
+
+  const printArea = document.createElement('section');
+  printArea.className = 'peo-print-area';
+  printArea.setAttribute('aria-hidden', 'true');
+  document.body.appendChild(printArea);
+
+  const reduceMotion = window.matchMedia ? window.matchMedia('(prefers-reduced-motion: reduce)').matches : false;
+
+  attachEventListeners();
+  updateTeacherModeButton();
+  updateFavoritesButton();
+  focusHeadingForHash();
+
+  fetch('data/peo-y9-activities.json')
+    .then(function(response){
+      if(!response.ok){ throw new Error('Network response was not ok'); }
+      return response.json();
+    })
+    .then(function(data){
+      initialiseData(data);
+      populateFilters();
+      renderActivities({ preserveOpen: false });
+    })
+    .catch(function(error){
+      console.error('Unable to load PEO activities', error);
+      grid.innerHTML = '';
+      const message = document.createElement('div');
+      message.className = 'empty-state';
+      message.textContent = 'We could not load the PEO activities right now. Please refresh to try again.';
+      grid.appendChild(message);
+    });
+
+  function initialiseData(data){
+    if(!data || !Array.isArray(data.topics)){ return; }
+    state.topics = data.topics.slice();
+    state.activities = state.topics.flatMap(function(topic, index){
+      const activities = Array.isArray(topic.activities) ? topic.activities : [];
+      return activities.map(function(activity){
+        return { topic: topic, activity: activity, topicIndex: index };
+      });
+    });
+    pruneStoredIds();
+  }
+
+  function pruneStoredIds(){
+    const validIds = new Set(state.activities.map(function(entry){ return entry.activity.id; }));
+    state.favorites = state.favorites.filter(function(id){ return validIds.has(id); });
+    state.selectedForPrint = state.selectedForPrint.filter(function(id){ return validIds.has(id); });
+    setStoredArray(STORAGE_KEYS.favorites, state.favorites);
+    setStoredArray(STORAGE_KEYS.selected, state.selectedForPrint);
+  }
+
+  function attachEventListeners(){
+    if(searchInput){
+      searchInput.addEventListener('input', debounce(function(event){
+        state.searchTerm = (event.target.value || '').trim().toLowerCase();
+        renderActivities();
+      }, 150));
+    }
+
+    if(topicSelect){
+      topicSelect.addEventListener('change', function(event){
+        state.topicFilter = event.target.value || 'all';
+        renderActivities();
+      });
+    }
+
+    if(typeSelect){
+      typeSelect.addEventListener('change', function(event){
+        state.typeFilter = event.target.value || 'all';
+        renderActivities();
+      });
+    }
+
+    if(favoritesBtn){
+      favoritesBtn.addEventListener('click', function(){
+        state.favoritesOnly = !state.favoritesOnly;
+        updateFavoritesButton();
+        renderActivities();
+      });
+    }
+
+    if(teacherModeBtn){
+      teacherModeBtn.addEventListener('click', function(){
+        state.teacherMode = !state.teacherMode;
+        setStoredBoolean(STORAGE_KEYS.teacherMode, state.teacherMode);
+        updateTeacherModeButton();
+        renderActivities();
+      });
+    }
+
+    if(printBtn){
+      printBtn.addEventListener('click', handlePrint);
+    }
+
+    window.addEventListener('hashchange', focusHeadingForHash);
+    window.addEventListener('afterprint', cleanUpPrintMode);
+  }
+
+  function populateFilters(){
+    if(topicSelect){
+      topicSelect.innerHTML = '';
+      const allOption = document.createElement('option');
+      allOption.value = 'all';
+      allOption.textContent = 'All topics';
+      topicSelect.appendChild(allOption);
+
+      state.topics.forEach(function(topic){
+        const option = document.createElement('option');
+        option.value = topic.id;
+        option.textContent = topic.title;
+        topicSelect.appendChild(option);
+      });
+
+      topicSelect.value = state.topicFilter;
+    }
+
+    if(typeSelect){
+      typeSelect.innerHTML = '';
+      const allOption = document.createElement('option');
+      allOption.value = 'all';
+      allOption.textContent = 'All types';
+      typeSelect.appendChild(allOption);
+
+      const types = Array.from(new Set(state.activities.flatMap(function(entry){
+        return Array.isArray(entry.activity.type) ? entry.activity.type : [];
+      })));
+      types.sort(function(a, b){
+        return a.localeCompare(b, undefined, { sensitivity: 'base' });
+      });
+
+      types.forEach(function(type){
+        const option = document.createElement('option');
+        option.value = type;
+        option.textContent = type;
+        typeSelect.appendChild(option);
+      });
+
+      typeSelect.value = state.typeFilter;
+    }
+  }
+
+  function renderActivities(options){
+    options = options || {};
+    const preserveOpen = options.preserveOpen !== false;
+    const openIds = preserveOpen ? getOpenActivityIds() : new Set();
+
+    grid.innerHTML = '';
+    if(!state.activities.length){
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.textContent = 'No activities available.';
+      grid.appendChild(empty);
+      return;
+    }
+
+    const filtered = state.activities.filter(function(entry){
+      const activity = entry.activity;
+      if(state.favoritesOnly && !isFavorite(activity.id)){ return false; }
+      if(state.topicFilter !== 'all' && entry.topic.id !== state.topicFilter){ return false; }
+      if(state.typeFilter !== 'all' && !(Array.isArray(activity.type) && activity.type.includes(state.typeFilter))){ return false; }
+      if(state.searchTerm){
+        const haystack = [
+          activity.title,
+          (activity.objectives || []).join(' '),
+          (activity.tags || []).join(' ')
+        ].join(' ').toLowerCase();
+        if(!haystack.includes(state.searchTerm)){ return false; }
+      }
+      return true;
+    });
+
+    if(!filtered.length){
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.textContent = 'No activities match your filters yet. Try adjusting your search or filters.';
+      grid.appendChild(empty);
+      return;
+    }
+
+    filtered.sort(function(a, b){
+      const favDelta = Number(isFavorite(b.activity.id)) - Number(isFavorite(a.activity.id));
+      if(favDelta !== 0){ return favDelta; }
+      if(a.topicIndex !== b.topicIndex){ return a.topicIndex - b.topicIndex; }
+      return a.activity.title.localeCompare(b.activity.title, undefined, { sensitivity: 'base' });
+    });
+
+    filtered.forEach(function(entry){
+      const activity = entry.activity;
+      const topic = entry.topic;
+      const isFav = isFavorite(activity.id);
+      const isSelected = state.selectedForPrint.includes(activity.id);
+      const bodyId = 'activity-' + activity.id;
+      const article = document.createElement('article');
+      article.className = 'activity-card' + (isFav ? ' favorited' : '');
+
+      const header = document.createElement('div');
+      header.className = 'activity-header';
+
+      const toggleBtn = document.createElement('button');
+      toggleBtn.className = 'activity-toggle';
+      toggleBtn.type = 'button';
+      toggleBtn.setAttribute('aria-expanded', openIds.has(activity.id) ? 'true' : 'false');
+      toggleBtn.setAttribute('aria-controls', bodyId);
+
+      const titleSpan = document.createElement('span');
+      titleSpan.className = 'activity-title';
+      titleSpan.textContent = activity.title;
+      toggleBtn.appendChild(titleSpan);
+
+      const meta = document.createElement('div');
+      meta.className = 'activity-meta';
+
+      if(isFav){
+        const favFlag = document.createElement('span');
+        favFlag.className = 'favorite-flag';
+        const star = document.createElement('span');
+        star.className = 'star';
+        star.setAttribute('aria-hidden', 'true');
+        star.textContent = '★';
+        const flagLabel = document.createElement('span');
+        flagLabel.textContent = 'Favourite';
+        favFlag.appendChild(star);
+        favFlag.appendChild(flagLabel);
+        meta.appendChild(favFlag);
+      }
+
+      const topicChip = document.createElement('span');
+      topicChip.className = 'topic-chip';
+      topicChip.style.backgroundColor = topic.color || '#0f172a';
+      const topicLabel = document.createElement('span');
+      topicLabel.className = 'topic-label';
+      topicLabel.textContent = topic.title;
+      topicChip.appendChild(topicLabel);
+      meta.appendChild(topicChip);
+
+      if(activity.duration){
+        const duration = document.createElement('span');
+        duration.className = 'duration-pill';
+        duration.textContent = activity.duration;
+        meta.appendChild(duration);
+      }
+
+      if(Array.isArray(activity.type)){
+        activity.type.forEach(function(type){
+          const typeChip = document.createElement('span');
+          typeChip.className = 'type-chip';
+          typeChip.textContent = type;
+          meta.appendChild(typeChip);
+        });
+      }
+
+      toggleBtn.appendChild(meta);
+      header.appendChild(toggleBtn);
+
+      const favoriteButton = document.createElement('button');
+      favoriteButton.className = 'favorite-btn';
+      favoriteButton.type = 'button';
+      favoriteButton.setAttribute('aria-pressed', isFav ? 'true' : 'false');
+      favoriteButton.setAttribute('aria-label', (isFav ? 'Remove' : 'Save') + ' ' + activity.title + ' to favourites');
+      favoriteButton.innerHTML = '<span class="star" aria-hidden="true">★</span><span class="favorite-label">' + (isFav ? 'Saved' : 'Save') + '</span>';
+      favoriteButton.addEventListener('click', function(){
+        toggleFavorite(activity.id);
+        renderActivities();
+      });
+      header.appendChild(favoriteButton);
+
+      article.appendChild(header);
+
+      const actions = document.createElement('div');
+      actions.className = 'activity-actions';
+      if(activity.grouping){
+        const grouping = document.createElement('span');
+        grouping.className = 'grouping-label';
+        grouping.textContent = 'Grouping: ' + activity.grouping;
+        actions.appendChild(grouping);
+      }
+
+      const selectLabel = document.createElement('label');
+      selectLabel.setAttribute('for', 'select-' + activity.id);
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.id = 'select-' + activity.id;
+      checkbox.checked = isSelected;
+      checkbox.addEventListener('change', function(event){
+        toggleSelected(activity.id, event.target.checked);
+      });
+      const labelText = document.createElement('span');
+      labelText.textContent = 'Select for print';
+      selectLabel.appendChild(checkbox);
+      selectLabel.appendChild(labelText);
+      actions.appendChild(selectLabel);
+      article.appendChild(actions);
+
+      const body = document.createElement('div');
+      body.className = 'activity-body';
+      body.id = bodyId;
+      body.dataset.activityId = activity.id;
+      body.hidden = !openIds.has(activity.id);
+
+      if(activity.objectives && activity.objectives.length){
+        const objectivesWrap = document.createElement('div');
+        const headingEl = document.createElement('h3');
+        headingEl.textContent = 'Learning objectives';
+        const list = document.createElement('ul');
+        activity.objectives.forEach(function(item){
+          const li = document.createElement('li');
+          li.textContent = item;
+          list.appendChild(li);
+        });
+        objectivesWrap.appendChild(headingEl);
+        objectivesWrap.appendChild(list);
+        body.appendChild(objectivesWrap);
+      }
+
+      if(activity.materials && activity.materials.length){
+        const materialsWrap = document.createElement('div');
+        const headingEl = document.createElement('h3');
+        headingEl.textContent = 'Materials';
+        const list = document.createElement('ul');
+        activity.materials.forEach(function(item){
+          const li = document.createElement('li');
+          li.textContent = item;
+          list.appendChild(li);
+        });
+        materialsWrap.appendChild(headingEl);
+        materialsWrap.appendChild(list);
+        body.appendChild(materialsWrap);
+      }
+
+      if(activity.steps && activity.steps.length){
+        const stepsWrap = document.createElement('div');
+        const headingEl = document.createElement('h3');
+        headingEl.textContent = 'Steps';
+        const list = document.createElement('ol');
+        activity.steps.forEach(function(item){
+          const li = document.createElement('li');
+          li.textContent = item;
+          list.appendChild(li);
+        });
+        stepsWrap.appendChild(headingEl);
+        stepsWrap.appendChild(list);
+        body.appendChild(stepsWrap);
+      }
+
+      if(activity.assessment){
+        const assessment = document.createElement('p');
+        const label = document.createElement('strong');
+        label.textContent = 'Assessment:';
+        assessment.appendChild(label);
+        assessment.appendChild(document.createTextNode(' ' + activity.assessment));
+        body.appendChild(assessment);
+      }
+
+      if(activity.links && activity.links.length){
+        const linksWrap = document.createElement('div');
+        const headingEl = document.createElement('h3');
+        headingEl.textContent = 'Links';
+        const list = document.createElement('div');
+        list.className = 'links-list';
+        activity.links.forEach(function(link){
+          if(!link || !link.url){ return; }
+          const anchor = document.createElement('a');
+          const labelText = link.label || link.url;
+          anchor.href = link.url;
+          anchor.target = '_blank';
+          anchor.rel = 'noopener noreferrer';
+          anchor.innerHTML = labelText + '<span class="outbound-icon" aria-hidden="true">↗</span><span class="sr-only"> opens in a new tab</span>';
+          list.appendChild(anchor);
+        });
+        linksWrap.appendChild(headingEl);
+        linksWrap.appendChild(list);
+        body.appendChild(linksWrap);
+      }
+
+      const tipText = teacherTips[activity.id];
+      if(tipText){
+        const tip = document.createElement('div');
+        tip.className = 'teacher-tip';
+        if(!state.teacherMode){ tip.hidden = true; }
+        const strong = document.createElement('strong');
+        strong.textContent = 'Teacher tips';
+        const text = document.createElement('p');
+        text.textContent = tipText;
+        tip.appendChild(strong);
+        tip.appendChild(text);
+        body.appendChild(tip);
+      }
+
+      article.appendChild(body);
+
+      toggleBtn.addEventListener('click', function(){
+        const isExpanded = toggleBtn.getAttribute('aria-expanded') === 'true';
+        toggleBtn.setAttribute('aria-expanded', isExpanded ? 'false' : 'true');
+        body.hidden = isExpanded;
+      });
+
+      grid.appendChild(article);
+    });
+  }
+
+  function getOpenActivityIds(){
+    const bodies = grid ? grid.querySelectorAll('.activity-body') : [];
+    const open = new Set();
+    bodies.forEach(function(body){
+      if(!body.hidden && body.dataset && body.dataset.activityId){
+        open.add(body.dataset.activityId);
+      }
+    });
+    return open;
+  }
+
+  function toggleFavorite(activityId){
+    const index = state.favorites.indexOf(activityId);
+    if(index === -1){
+      state.favorites.push(activityId);
+    } else {
+      state.favorites.splice(index, 1);
+    }
+    setStoredArray(STORAGE_KEYS.favorites, state.favorites);
+    updateFavoritesButton();
+  }
+
+  function toggleSelected(activityId, isSelected){
+    const idx = state.selectedForPrint.indexOf(activityId);
+    if(isSelected && idx === -1){
+      state.selectedForPrint.push(activityId);
+    }
+    if(!isSelected && idx > -1){
+      state.selectedForPrint.splice(idx, 1);
+    }
+    setStoredArray(STORAGE_KEYS.selected, state.selectedForPrint);
+  }
+
+  function handlePrint(){
+    if(!state.selectedForPrint.length){
+      window.alert('Select at least one activity to print or export.');
+      return;
+    }
+    buildPrintArea();
+    document.body.classList.add('peo-printing');
+    printArea.setAttribute('aria-hidden', 'false');
+    window.print();
+    setTimeout(cleanUpPrintMode, 1000);
+  }
+
+  function buildPrintArea(){
+    printArea.innerHTML = '';
+    const title = document.createElement('h1');
+    title.textContent = 'PEO Year 9 Activities';
+    const formatter = new Intl.DateTimeFormat('en-AU', { dateStyle: 'full', timeZone: 'Australia/Adelaide' });
+    const meta = document.createElement('p');
+    meta.className = 'print-meta';
+    meta.textContent = 'Generated ' + formatter.format(new Date());
+    printArea.appendChild(title);
+    printArea.appendChild(meta);
+
+    const selectedSet = new Set(state.selectedForPrint);
+    const selectedEntries = state.activities.filter(function(entry){
+      return selectedSet.has(entry.activity.id);
+    });
+
+    selectedEntries.sort(function(a, b){
+      if(a.topicIndex !== b.topicIndex){ return a.topicIndex - b.topicIndex; }
+      return a.activity.title.localeCompare(b.activity.title, undefined, { sensitivity: 'base' });
+    });
+
+    selectedEntries.forEach(function(entry){
+      const activity = entry.activity;
+      const topic = entry.topic;
+      const container = document.createElement('article');
+      container.className = 'peo-print-activity';
+
+      const headingEl = document.createElement('h2');
+      headingEl.textContent = activity.title;
+      container.appendChild(headingEl);
+
+      const topicLine = document.createElement('p');
+      let topicText = 'Topic: ' + topic.title + ' • Duration: ' + (activity.duration || 'N/A');
+      if(activity.grouping){
+        topicText += ' • Grouping: ' + activity.grouping;
+      }
+      topicLine.textContent = topicText;
+      container.appendChild(topicLine);
+
+      if(activity.objectives && activity.objectives.length){
+        const label = document.createElement('strong');
+        label.textContent = 'Objectives';
+        container.appendChild(label);
+        const list = document.createElement('ul');
+        activity.objectives.forEach(function(item){
+          const li = document.createElement('li');
+          li.textContent = item;
+          list.appendChild(li);
+        });
+        container.appendChild(list);
+      }
+
+      if(activity.steps && activity.steps.length){
+        const stepsHeading = document.createElement('strong');
+        stepsHeading.textContent = 'Steps';
+        container.appendChild(stepsHeading);
+        const list = document.createElement('ol');
+        activity.steps.forEach(function(item){
+          const li = document.createElement('li');
+          li.textContent = item;
+          list.appendChild(li);
+        });
+        container.appendChild(list);
+      }
+
+      if(activity.materials && activity.materials.length){
+        const materialsHeading = document.createElement('strong');
+        materialsHeading.textContent = 'Materials';
+        container.appendChild(materialsHeading);
+        const list = document.createElement('ul');
+        activity.materials.forEach(function(item){
+          const li = document.createElement('li');
+          li.textContent = item;
+          list.appendChild(li);
+        });
+        container.appendChild(list);
+      }
+
+      if(activity.assessment){
+        const assess = document.createElement('p');
+        const bold = document.createElement('strong');
+        bold.textContent = 'Assessment:';
+        assess.appendChild(bold);
+        assess.appendChild(document.createTextNode(' ' + activity.assessment));
+        container.appendChild(assess);
+      }
+
+      if(activity.links && activity.links.length){
+        const linksHeading = document.createElement('strong');
+        linksHeading.textContent = 'Links';
+        container.appendChild(linksHeading);
+        const list = document.createElement('ul');
+        activity.links.forEach(function(link){
+          if(!link || !link.url){ return; }
+          const li = document.createElement('li');
+          const anchor = document.createElement('a');
+          anchor.href = link.url;
+          anchor.textContent = link.label || link.url;
+          anchor.target = '_blank';
+          anchor.rel = 'noopener noreferrer';
+          li.appendChild(anchor);
+          list.appendChild(li);
+        });
+        container.appendChild(list);
+      }
+
+      printArea.appendChild(container);
+    });
+  }
+
+  function cleanUpPrintMode(){
+    document.body.classList.remove('peo-printing');
+    printArea.setAttribute('aria-hidden', 'true');
+    printArea.innerHTML = '';
+  }
+
+  function focusHeadingForHash(){
+    if(window.location.hash !== '#peo-y9' || !heading){ return; }
+    if(typeof heading.focus === 'function'){
+      heading.focus({ preventScroll: true });
+    }
+    heading.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' });
+  }
+
+  function updateTeacherModeButton(){
+    if(!teacherModeBtn){ return; }
+    teacherModeBtn.setAttribute('aria-pressed', state.teacherMode ? 'true' : 'false');
+    teacherModeBtn.textContent = state.teacherMode ? 'Teacher Mode: On' : 'Teacher Mode: Off';
+  }
+
+  function updateFavoritesButton(){
+    if(!favoritesBtn){ return; }
+    favoritesBtn.setAttribute('aria-pressed', state.favoritesOnly ? 'true' : 'false');
+    favoritesBtn.textContent = state.favoritesOnly ? 'Favorites: On' : 'Favorites';
+  }
+
+  function isFavorite(activityId){
+    return state.favorites.includes(activityId);
+  }
+
+  function debounce(fn, wait){
+    let timeout;
+    return function(){
+      const args = arguments;
+      const context = this;
+      clearTimeout(timeout);
+      timeout = setTimeout(function(){
+        fn.apply(context, args);
+      }, wait);
+    };
+  }
+
+  function getStoredBoolean(key, fallback){
+    try {
+      const value = localStorage.getItem(key);
+      if(value === null){ return fallback; }
+      return value === 'true';
+    } catch(e){
+      return fallback;
+    }
+  }
+
+  function setStoredBoolean(key, value){
+    try {
+      localStorage.setItem(key, value ? 'true' : 'false');
+    } catch(e){}
+  }
+
+  function getStoredArray(key){
+    try {
+      const value = localStorage.getItem(key);
+      if(!value){ return []; }
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch(e){
+      return [];
+    }
+  }
+
+  function setStoredArray(key, arr){
+    try {
+      localStorage.setItem(key, JSON.stringify(arr));
+    } catch(e){}
+  }
+
+  setTimeout(focusHeadingForHash, 150);
+})();


### PR DESCRIPTION
## Summary
- add a skip link and primary navigation entry that anchors to the new PEO Year 9 section
- load the Australian Parliament Education Office Year 9 activities from JSON and render searchable, filterable cards with teacher mode, favourites and print selections
- layer bespoke styling and print layout so the grid, controls and export view match the site’s aesthetic and accessibility goals

## Testing
- python -m json.tool data/peo-y9-activities.json

------
https://chatgpt.com/codex/tasks/task_e_68c8c2b9ad808324bb1c5ed7b8c7053e