### PR TITLE
Add sequenced PEO Year 9 planner section

### DIFF
--- a/css/peo-y9.css
+++ b/css/peo-y9.css
@@ -15,6 +15,18 @@
   top: 0.75rem;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .section {
   background-color: rgba(255, 255, 255, 0.9);
   backdrop-filter: blur(8px);
@@ -90,6 +102,10 @@
   gap: 1rem;
 }
 
+#seqGrid {
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+}
+
 .activity-card {
   border-radius: 1rem;
   border: 1px solid #e2e8f0;
@@ -103,6 +119,100 @@
 .activity-card.favorited {
   border-color: #f59e0b;
   box-shadow: 0 18px 38px -28px rgba(217, 119, 6, 0.6);
+}
+
+.sequence-card {
+  border-left: 4px solid var(--sequence-accent, #334155);
+}
+
+.sequence-header {
+  align-items: stretch;
+  gap: 0.75rem;
+}
+
+.sequence-toggle {
+  width: 100%;
+}
+
+.sequence-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.75rem;
+  align-items: center;
+}
+
+.sequence-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background-color: rgba(15, 23, 42, 0.08);
+  color: #1e293b;
+}
+
+.sequence-chip .icon {
+  font-size: 0.85rem;
+}
+
+.sequence-chip--week {
+  background-color: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+}
+
+.sequence-topic {
+  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.12);
+}
+
+.sequence-topic .sequence-topic-icon {
+  font-size: 0.95rem;
+}
+
+.sequence-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.4rem;
+}
+
+.sequence-select {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: #334155;
+}
+
+.sequence-select input[type="checkbox"] {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--sequence-accent, #0f172a);
+}
+
+.sequence-body {
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+}
+
+.week-label {
+  grid-column: 1 / -1;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background-color: rgba(15, 23, 42, 0.05);
+  color: #0f172a;
+  border-radius: 0.75rem;
+  padding: 0.45rem 0.85rem;
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.week-label .icon {
+  font-size: 1.1rem;
 }
 
 .activity-header {
@@ -397,6 +507,21 @@ body.peo-printing .peo-print-activity h2 {
   .activity-actions label {
     margin-left: 0;
   }
+
+  .sequence-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sequence-actions {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .sequence-select {
+    font-size: 0.85rem;
+  }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -473,6 +598,33 @@ body.peo-printing .peo-print-activity h2 {
   .favorite-flag {
     background-color: rgba(251, 191, 36, 0.3);
     color: #fde68a;
+  }
+
+  .sequence-chip {
+    background-color: rgba(148, 163, 184, 0.2);
+    color: #e2e8f0;
+  }
+
+  .sequence-chip--week {
+    background-color: rgba(59, 130, 246, 0.25);
+    color: #bfdbfe;
+  }
+
+  .sequence-topic {
+    box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.3);
+  }
+
+  .sequence-select {
+    color: #e2e8f0;
+  }
+
+  .sequence-body {
+    border-top-color: rgba(148, 163, 184, 0.35);
+  }
+
+  .week-label {
+    background-color: rgba(148, 163, 184, 0.18);
+    color: #f8fafc;
   }
 
   body.peo-printing {

--- a/data/peo-y9-sequenced.json
+++ b/data/peo-y9-sequenced.json
@@ -1,0 +1,258 @@
+{
+  "sequence": [
+    {
+      "id": "wk1-media-bias-starter",
+      "week": 1,
+      "lessonOrder": 1,
+      "topicId": "media-literacy",
+      "topicTitle": "Media Literacy",
+      "title": "Facts vs Opinion + Bias Starter",
+      "duration": "30–45 min",
+      "grouping": "Pairs → Whole class",
+      "objectives": [
+        "Differentiate fact vs opinion in current news",
+        "Identify bias and techniques in headlines"
+      ],
+      "visibleLearning": {
+        "learningIntentions": "We are learning to distinguish fact, opinion and bias in media.",
+        "successCriteria": [
+          "I can label statements as fact/opinion with reasons",
+          "I can name one bias technique used in a headline"
+        ]
+      },
+      "materials": ["Curated headlines set", "Highlighters", "Exit ticket"],
+      "steps": [
+        "Hook: two contrasting headlines; quick decide ‘fact/opinion’ and why.",
+        "Pairs annotate a mixed set; highlight claims, evidence, emotive language.",
+        "Whole class: build a mini ‘bias bingo’ list for future spotting."
+      ],
+      "assessment": "Exit ticket: 1 fact claim + 1 opinion claim with justification.",
+      "links": [
+        {"label": "PEO Y9 Units", "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"}
+      ],
+      "tags": ["media", "bias", "critical-thinking"],
+      "teacherTips": [
+        "Differentiation: provide sentence starters for justifications.",
+        "Formative: cold-call a few pairs to model precise language."
+      ]
+    },
+    {
+      "id": "wk1-news-diet",
+      "week": 1,
+      "lessonOrder": 2,
+      "topicId": "media-literacy",
+      "topicTitle": "Media Literacy",
+      "title": "News Diet Challenge (48-hour)",
+      "duration": "Homework + 20 min debrief",
+      "grouping": "Individual → Pairs",
+      "objectives": ["Audit personal news intake", "Plan one improvement to balance sources"],
+      "visibleLearning": {
+        "learningIntentions": "We are learning to reflect on the diversity and reliability of our news sources.",
+        "successCriteria": [
+          "I can categorise sources by type and reliability",
+          "I can name one concrete change to improve my news diet"
+        ]
+      },
+      "materials": ["News diet log (template)"],
+      "steps": [
+        "Students track sources for 48h.",
+        "Pairs swap logs, classify and suggest one improvement.",
+        "Debrief: share common patterns and quick wins."
+      ],
+      "assessment": "Collect logs; check categorisation + improvement suggestion.",
+      "links": [
+        {"label": "PEO Y9 Units – Media", "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"}
+      ],
+      "tags": ["media", "metacognition"],
+      "teacherTips": ["ELL support: picture icons for source types."]
+    },
+    {
+      "id": "wk2-parties-frayer",
+      "week": 2,
+      "lessonOrder": 3,
+      "topicId": "political-parties",
+      "topicTitle": "Political Parties",
+      "title": "Frayer Model: Party Ideology",
+      "duration": "45–60 min",
+      "grouping": "Small groups",
+      "objectives": [
+        "Define key ideological terms and apply with examples",
+        "Compare policy positions across parties"
+      ],
+      "visibleLearning": {
+        "learningIntentions": "We are learning to describe and compare party ideologies.",
+        "successCriteria": [
+          "I can complete a Frayer with clear examples/non-examples",
+          "I can contrast two parties on one policy area"
+        ]
+      },
+      "materials": ["Frayer template", "Party fact sheets"],
+      "steps": [
+        "Assign terms/parties to groups; complete Frayer.",
+        "Gallery walk with ‘two stars and a wish’.",
+        "Class builds a comparative table for one policy (e.g., climate)."
+      ],
+      "assessment": "Collect Frayers; check accuracy and evidence use.",
+      "links": [{"label": "PEO – Parties", "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"}],
+      "tags": ["ideology", "compare-contrast"],
+      "teacherTips": ["Offer sentence frames for compare/contrast."]
+    },
+    {
+      "id": "wk3-bill-simulation",
+      "week": 3,
+      "lessonOrder": 4,
+      "topicId": "parliament-law-making",
+      "topicTitle": "Parliament & Law-Making",
+      "title": "How a Bill Becomes Law – Role-Play",
+      "duration": "60–90 min",
+      "grouping": "Whole class roles",
+      "objectives": [
+        "Explain stages of a bill",
+        "Experience debate, amendment and voting processes"
+      ],
+      "visibleLearning": {
+        "learningIntentions": "We are learning the stages of federal law-making.",
+        "successCriteria": [
+          "I can name the main stages and what happens at each",
+          "I can describe the purpose of amendments and committees"
+        ]
+      },
+      "materials": ["Role cards", "Bill summary", "Chamber layout"],
+      "steps": [
+        "Assign roles (Speaker/President, Govt/Opposition, Crossbench, Clerks, Whips, Media).",
+        "Run through readings, debate, optional committee, amendments, vote.",
+        "Debrief: map our simulation to the official process."
+      ],
+      "assessment": "Quick-write: which stage most influences outcomes and why?",
+      "links": [{"label": "PEO – Making Laws", "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"}],
+      "tags": ["parliament", "procedure", "debate"],
+      "teacherTips": ["Timebox speeches; use traffic-light cards to manage talk time."]
+    },
+    {
+      "id": "wk4-cards-against-calamity-bridge",
+      "week": 4,
+      "lessonOrder": 5,
+      "topicId": "integration",
+      "topicTitle": "Integration",
+      "title": "Bridge: From Bill Process → Policy Trade-offs (Cards Against Calamity)",
+      "duration": "60 min",
+      "grouping": "Teams",
+      "objectives": [
+        "Connect legislative steps to real policy trade-offs",
+        "Practice stakeholder reasoning and justification"
+      ],
+      "visibleLearning": {
+        "learningIntentions": "We are learning how competing priorities shape policy outcomes.",
+        "successCriteria": [
+          "I can justify a policy choice with stakeholder evidence",
+          "I can explain how an amendment could shift outcomes"
+        ]
+      },
+      "materials": ["Cards Against Calamity game set", "Decision log sheet"],
+      "steps": [
+        "Teams play a shortened round focused on one issue.",
+        "Each decision logged with ‘who benefits / who loses / evidence’.",
+        "Share-out: connect decisions to potential legislative amendments."
+      ],
+      "assessment": "Collect decision logs; check justified reasoning.",
+      "links": [],
+      "tags": ["simulation", "stakeholders", "reasoning"],
+      "teacherTips": ["Assign rotating role: ‘evidence officer’ to cite sources."]
+    },
+    {
+      "id": "wk5-courts-mock-hearing",
+      "week": 5,
+      "lessonOrder": 6,
+      "topicId": "courts-justice",
+      "topicTitle": "Courts & Justice",
+      "title": "Mock Hearing: Courts Support Democracy",
+      "duration": "45–70 min",
+      "grouping": "Small groups → plenary",
+      "objectives": [
+        "Identify court roles and processes",
+        "Explain rule of law and judicial independence"
+      ],
+      "visibleLearning": {
+        "learningIntentions": "We are learning how courts ensure fairness in a democracy.",
+        "successCriteria": [
+          "I can describe roles in a hearing",
+          "I can use the term ‘judicial independence’ correctly"
+        ]
+      },
+      "materials": ["Case summary", "Role cards", "Observer checklist"],
+      "steps": [
+        "Groups stage a short hearing with set roles.",
+        "Observers complete fairness/due-process checklist.",
+        "Compare outcomes; discuss consistency and appeals."
+      ],
+      "assessment": "Reflection paragraph on fairness and due process.",
+      "links": [{"label": "PEO – Courts & Justice", "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"}],
+      "tags": ["rule-of-law", "fairness"],
+      "teacherTips": ["Offer simplified scripts for EAL/D students."]
+    },
+    {
+      "id": "wk6-citizen-petition-plan",
+      "week": 6,
+      "lessonOrder": 7,
+      "topicId": "citizen-participation",
+      "topicTitle": "Citizen Participation",
+      "title": "Petition & Lobby Plan (Local Issue)",
+      "duration": "50–70 min",
+      "grouping": "Teams",
+      "objectives": [
+        "Map an issue, stakeholders and lawful action pathway",
+        "Draft a persuasive petition and outreach plan"
+      ],
+      "visibleLearning": {
+        "learningIntentions": "We are learning to plan a lawful, effective avenue for change.",
+        "successCriteria": [
+          "I can write a clear ‘ask’ with reasons and evidence",
+          "I can identify decision-makers and next steps"
+        ]
+      },
+      "materials": ["Stakeholder map template", "Petition template"],
+      "steps": [
+        "Choose a local issue; map stakeholders/decision-makers.",
+        "Draft petition text (clear ask, reasons, evidence).",
+        "Plan outreach (meetings/letters/social media etiquette)."
+      ],
+      "assessment": "Submit a 1-page plan with SMART next steps.",
+      "links": [{"label": "PEO – Participation", "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"}],
+      "tags": ["advocacy", "civics-action"],
+      "teacherTips": ["Model a sample paragraph using TEAL/PEEL."]
+    },
+    {
+      "id": "wk7-summative-inquiry",
+      "week": 7,
+      "lessonOrder": 8,
+      "topicId": "assessment",
+      "topicTitle": "Assessment",
+      "title": "Civics Inquiry (Student Choice Product)",
+      "duration": "Multi-lesson",
+      "grouping": "Individual or pairs",
+      "objectives": [
+        "Investigate a civics issue and present evidence-based recommendations"
+      ],
+      "visibleLearning": {
+        "learningIntentions": "We are learning to investigate and communicate a civics issue using evidence.",
+        "successCriteria": [
+          "I can formulate a guiding question",
+          "I can evaluate sources for reliability and bias",
+          "I can present justified recommendations"
+        ]
+      },
+      "materials": ["Inquiry guide", "Rubric", "Presentation templates"],
+      "steps": [
+        "Define guiding question aligned to content descriptors.",
+        "Collect/evaluate sources; track evidence.",
+        "Present via report, video, podcast, **Minecraft build**, infographic or live talk."
+      ],
+      "assessment": "Rubric aligned to ACARA Y9 Civics & Citizenship.",
+      "links": [],
+      "tags": ["inquiry", "communication", "student-choice"],
+      "teacherTips": [
+        "Offer conferencing checkpoints; provide exemplars for each mode."
+      ]
+    }
+  ]
+}

--- a/index.htm
+++ b/index.htm
@@ -7,6 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="css/peo-y9.css" />
   <script defer src="js/peo-y9.js"></script>
+  <script defer src="js/peo-y9-sequenced.js"></script>
   <style>
     :root{ --ring: 219 14% 28%; }
     .focus-ring:focus{ outline: 2px solid hsl(var(--ring)); outline-offset: 2px; }
@@ -50,6 +51,9 @@
           <li>
             <a class="rounded-lg px-3 py-2 hover:bg-slate-100 focus-ring" href="#peo-y9">PEO Year 9 Activities</a>
           </li>
+          <li>
+            <a class="rounded-lg px-3 py-2 hover:bg-slate-100 focus-ring" href="#peo-y9-sequenced">PEO Y9 – Sequenced</a>
+          </li>
         </ul>
       </div>
     </nav>
@@ -92,6 +96,22 @@
 
       <!-- Rendered cards go here -->
       <div id="activitiesGrid" class="grid"></div>
+    </section>
+
+    <section id="peo-y9-sequenced" class="section">
+      <h2 tabindex="-1">PEO Year 9 – Sequenced Activities</h2>
+
+      <div class="controls">
+        <label class="sr-only" for="sequenceWeek">Jump to week</label>
+        <select id="sequenceWeek"></select>
+
+        <input id="searchSeq" type="search" placeholder="Search activities, aims, tags…" aria-label="Search activities" />
+        <button id="toggleTeacherMode2" aria-pressed="false">Teacher Mode: Off</button>
+        <button id="showFavorites2" aria-pressed="false">Show Favourites</button>
+        <button id="printSelected2">Print/Export Selected</button>
+      </div>
+
+      <div id="seqGrid" class="grid"></div>
     </section>
   </main>
 

--- a/js/peo-y9-sequenced.js
+++ b/js/peo-y9-sequenced.js
@@ -1,0 +1,733 @@
+(function(){
+  const section = document.getElementById('peo-y9-sequenced');
+  if(!section){ return; }
+
+  const heading = section.querySelector('h2');
+  const weekSelect = section.querySelector('#sequenceWeek');
+  const searchInput = section.querySelector('#searchSeq');
+  const teacherModeBtn = section.querySelector('#toggleTeacherMode2');
+  const favoritesBtn = section.querySelector('#showFavorites2');
+  const printBtn = section.querySelector('#printSelected2');
+  const grid = section.querySelector('#seqGrid');
+
+  const STORAGE_KEYS = {
+    teacherMode: 'peoY9Seq.teacherMode',
+    favorites: 'peoY9Seq.favorites',
+    selected: 'peoY9Seq.selected'
+  };
+
+  const state = {
+    items: [],
+    weekFilter: 'all',
+    searchTerm: '',
+    favoritesOnly: false,
+    teacherMode: getStoredBoolean(STORAGE_KEYS.teacherMode, false),
+    favorites: getStoredArray(STORAGE_KEYS.favorites),
+    selected: getStoredArray(STORAGE_KEYS.selected),
+    expanded: new Set()
+  };
+
+  const reduceMotion = window.matchMedia ? window.matchMedia('(prefers-reduced-motion: reduce)').matches : false;
+
+  const TOPIC_ACCENTS = {
+    'media-literacy': { color: '#1d4ed8', chip: '#2563eb', text: '#ffffff', icon: '📰' },
+    'political-parties': { color: '#7c3aed', chip: '#6d28d9', text: '#ffffff', icon: '🏛️' },
+    'parliament-law-making': { color: '#0ea5e9', chip: '#0284c7', text: '#ffffff', icon: '📜' },
+    integration: { color: '#059669', chip: '#047857', text: '#ffffff', icon: '🔗' },
+    'courts-justice': { color: '#dc2626', chip: '#b91c1c', text: '#ffffff', icon: '⚖️' },
+    'citizen-participation': { color: '#f97316', chip: '#ea580c', text: '#ffffff', icon: '🤝' },
+    assessment: { color: '#9333ea', chip: '#7e22ce', text: '#ffffff', icon: '🧭' }
+  };
+
+  const DEFAULT_ACCENT = { color: '#334155', chip: '#475569', text: '#ffffff', icon: '⭐' };
+
+  let printArea = document.querySelector('.peo-print-area');
+  if(!printArea){
+    printArea = document.createElement('section');
+    printArea.className = 'peo-print-area';
+    printArea.setAttribute('aria-hidden', 'true');
+    document.body.appendChild(printArea);
+  }
+
+  attachEventListeners();
+  updateTeacherModeButton();
+  updateFavoritesButton();
+  if(searchInput){ searchInput.value = state.searchTerm; }
+  focusHeadingForHash();
+
+  fetch('data/peo-y9-sequenced.json')
+    .then(function(response){
+      if(!response.ok){ throw new Error('Network response was not ok'); }
+      return response.json();
+    })
+    .then(function(data){
+      initialiseData(data);
+      populateWeekSelect();
+      renderSequence();
+    })
+    .catch(function(error){
+      console.error('Unable to load PEO sequenced activities', error);
+      if(grid){
+        grid.innerHTML = '';
+        const message = document.createElement('div');
+        message.className = 'empty-state';
+        message.textContent = 'We could not load the sequenced plan right now. Please refresh to try again.';
+        grid.appendChild(message);
+      }
+    });
+
+  function attachEventListeners(){
+    if(weekSelect){
+      weekSelect.addEventListener('change', function(event){
+        state.weekFilter = event.target.value || 'all';
+        renderSequence();
+      });
+    }
+
+    if(searchInput){
+      searchInput.addEventListener('input', debounce(function(event){
+        state.searchTerm = (event.target.value || '').trim().toLowerCase();
+        renderSequence();
+      }, 150));
+    }
+
+    if(teacherModeBtn){
+      teacherModeBtn.addEventListener('click', function(){
+        state.teacherMode = !state.teacherMode;
+        setStoredBoolean(STORAGE_KEYS.teacherMode, state.teacherMode);
+        updateTeacherModeButton();
+        renderSequence();
+      });
+    }
+
+    if(favoritesBtn){
+      favoritesBtn.addEventListener('click', function(){
+        state.favoritesOnly = !state.favoritesOnly;
+        updateFavoritesButton();
+        renderSequence();
+      });
+    }
+
+    if(printBtn){
+      printBtn.addEventListener('click', handlePrint);
+    }
+
+    window.addEventListener('hashchange', focusHeadingForHash);
+    window.addEventListener('afterprint', cleanUpPrintMode);
+  }
+
+  function initialiseData(data){
+    if(!data || !Array.isArray(data.sequence)){ return; }
+    state.items = data.sequence.slice().sort(function(a, b){
+      if(a.week !== b.week){ return a.week - b.week; }
+      if(a.lessonOrder !== b.lessonOrder){ return a.lessonOrder - b.lessonOrder; }
+      return a.title.localeCompare(b.title, undefined, { sensitivity: 'base' });
+    });
+    pruneStoredIds();
+  }
+
+  function populateWeekSelect(){
+    if(!weekSelect){ return; }
+    weekSelect.innerHTML = '';
+    const allOption = document.createElement('option');
+    allOption.value = 'all';
+    allOption.textContent = 'All weeks';
+    weekSelect.appendChild(allOption);
+
+    const weeks = Array.from(new Set(state.items.map(function(item){ return item.week; }))).sort(function(a, b){ return a - b; });
+    weeks.forEach(function(week){
+      const option = document.createElement('option');
+      option.value = String(week);
+      option.textContent = 'Week ' + week;
+      weekSelect.appendChild(option);
+    });
+
+    weekSelect.value = state.weekFilter;
+  }
+
+  function renderSequence(){
+    if(!grid){ return; }
+    grid.innerHTML = '';
+
+    if(!state.items.length){
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.textContent = 'No sequenced activities available yet.';
+      grid.appendChild(empty);
+      return;
+    }
+
+    const filtered = state.items.filter(function(item){
+      if(state.weekFilter !== 'all' && String(item.week) !== state.weekFilter){ return false; }
+      if(state.favoritesOnly && !isFavorite(item.id)){ return false; }
+      if(state.searchTerm){
+        const searchTarget = [
+          item.title,
+          (item.objectives || []).join(' '),
+          item.visibleLearning ? item.visibleLearning.learningIntentions : '',
+          item.visibleLearning ? (item.visibleLearning.successCriteria || []).join(' ') : '',
+          (item.tags || []).join(' ')
+        ].join(' ').toLowerCase();
+        if(searchTarget.indexOf(state.searchTerm) === -1){ return false; }
+      }
+      return true;
+    });
+
+    if(!filtered.length){
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.textContent = 'No activities match your filters yet.';
+      grid.appendChild(empty);
+      return;
+    }
+
+    let currentWeek = null;
+    filtered.forEach(function(item){
+      if(currentWeek !== item.week){
+        currentWeek = item.week;
+        grid.appendChild(createWeekLabel(item.week));
+      }
+      grid.appendChild(buildCard(item));
+    });
+  }
+
+  function buildCard(item){
+    const accent = TOPIC_ACCENTS[item.topicId] || DEFAULT_ACCENT;
+    const card = document.createElement('article');
+    card.className = 'activity-card sequence-card';
+    card.style.setProperty('--sequence-accent', accent.color);
+    if(isFavorite(item.id)){
+      card.classList.add('favorited');
+    }
+
+    const header = document.createElement('div');
+    header.className = 'activity-header sequence-header';
+
+    const bodyId = 'seq-' + item.id;
+    const isExpanded = state.expanded.has(item.id);
+
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'activity-toggle sequence-toggle';
+    toggle.setAttribute('aria-controls', bodyId);
+    toggle.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+
+    const title = document.createElement('span');
+    title.className = 'activity-title';
+    title.textContent = item.title;
+    toggle.appendChild(title);
+
+    const meta = document.createElement('div');
+    meta.className = 'activity-meta sequence-meta';
+
+    const weekChip = document.createElement('span');
+    weekChip.className = 'sequence-chip sequence-chip--week';
+    weekChip.textContent = 'Week ' + item.week + ' · Lesson ' + item.lessonOrder;
+    meta.appendChild(weekChip);
+
+    if(item.duration){
+      const duration = document.createElement('span');
+      duration.className = 'duration-pill';
+      duration.textContent = item.duration;
+      meta.appendChild(duration);
+    }
+
+    const topicChip = document.createElement('span');
+    topicChip.className = 'topic-chip sequence-topic';
+    topicChip.style.backgroundColor = accent.chip;
+    topicChip.style.color = accent.text;
+    const topicIcon = document.createElement('span');
+    topicIcon.className = 'sequence-topic-icon';
+    topicIcon.setAttribute('aria-hidden', 'true');
+    topicIcon.textContent = accent.icon;
+    const topicLabel = document.createElement('span');
+    topicLabel.className = 'topic-label';
+    topicLabel.textContent = item.topicTitle;
+    topicChip.appendChild(topicIcon);
+    topicChip.appendChild(topicLabel);
+    meta.appendChild(topicChip);
+
+    toggle.appendChild(meta);
+
+    const content = buildCardBody(item, bodyId, isExpanded);
+
+    toggle.addEventListener('click', function(){
+      const expanded = toggle.getAttribute('aria-expanded') === 'true';
+      const nextState = !expanded;
+      toggle.setAttribute('aria-expanded', nextState ? 'true' : 'false');
+      content.hidden = !nextState;
+      if(nextState){
+        state.expanded.add(item.id);
+      } else {
+        state.expanded.delete(item.id);
+      }
+    });
+
+    header.appendChild(toggle);
+
+    const actions = document.createElement('div');
+    actions.className = 'sequence-actions';
+
+    const favoriteButton = document.createElement('button');
+    favoriteButton.type = 'button';
+    favoriteButton.className = 'favorite-btn';
+    const favState = isFavorite(item.id);
+    favoriteButton.setAttribute('aria-pressed', favState ? 'true' : 'false');
+    favoriteButton.setAttribute('aria-label', favState ? 'Remove from favourites' : 'Add to favourites');
+    favoriteButton.title = favState ? 'Remove from favourites' : 'Add to favourites';
+    favoriteButton.innerHTML = '<span class="star" aria-hidden="true">' + (favState ? '★' : '☆') + '</span><span class="favorite-label">' + (favState ? 'Saved' : 'Save') + '</span>';
+    favoriteButton.addEventListener('click', function(){
+      toggleFavorite(item.id);
+      renderSequence();
+    });
+    actions.appendChild(favoriteButton);
+
+    const selectId = 'seq-select-' + item.id;
+    const selectLabel = document.createElement('label');
+    selectLabel.className = 'sequence-select';
+    selectLabel.setAttribute('for', selectId);
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.id = selectId;
+    checkbox.checked = isSelected(item.id);
+    checkbox.addEventListener('change', function(event){
+      toggleSelected(item.id, event.target.checked);
+    });
+    const labelText = document.createElement('span');
+    labelText.textContent = 'Include for print';
+    selectLabel.appendChild(checkbox);
+    selectLabel.appendChild(labelText);
+    actions.appendChild(selectLabel);
+
+    header.appendChild(actions);
+
+    card.appendChild(header);
+    card.appendChild(content);
+
+    return card;
+  }
+
+  function buildCardBody(item, bodyId, isExpanded){
+    const body = document.createElement('div');
+    body.className = 'activity-body sequence-body';
+    body.id = bodyId;
+    body.hidden = !isExpanded;
+
+    if(item.grouping){
+      const grouping = document.createElement('p');
+      grouping.className = 'grouping-label';
+      grouping.textContent = 'Grouping: ' + item.grouping;
+      body.appendChild(grouping);
+    }
+
+    if(item.visibleLearning){
+      if(item.visibleLearning.learningIntentions){
+        const liHeading = document.createElement('h3');
+        liHeading.textContent = 'Learning Intentions';
+        body.appendChild(liHeading);
+
+        const liParagraph = document.createElement('p');
+        liParagraph.textContent = item.visibleLearning.learningIntentions;
+        body.appendChild(liParagraph);
+      }
+
+      if(Array.isArray(item.visibleLearning.successCriteria) && item.visibleLearning.successCriteria.length){
+        const scHeading = document.createElement('h3');
+        scHeading.textContent = 'Success Criteria';
+        body.appendChild(scHeading);
+
+        const scList = document.createElement('ul');
+        item.visibleLearning.successCriteria.forEach(function(criteria){
+          const li = document.createElement('li');
+          li.textContent = criteria;
+          scList.appendChild(li);
+        });
+        body.appendChild(scList);
+      }
+    }
+
+    if(Array.isArray(item.objectives) && item.objectives.length){
+      const objectivesHeading = document.createElement('h3');
+      objectivesHeading.textContent = 'Objectives';
+      body.appendChild(objectivesHeading);
+
+      const objectivesList = document.createElement('ul');
+      item.objectives.forEach(function(obj){
+        const li = document.createElement('li');
+        li.textContent = obj;
+        objectivesList.appendChild(li);
+      });
+      body.appendChild(objectivesList);
+    }
+
+    if(Array.isArray(item.materials) && item.materials.length){
+      const materialsHeading = document.createElement('h3');
+      materialsHeading.textContent = 'Materials';
+      body.appendChild(materialsHeading);
+
+      const materialsList = document.createElement('ul');
+      item.materials.forEach(function(material){
+        const li = document.createElement('li');
+        li.textContent = material;
+        materialsList.appendChild(li);
+      });
+      body.appendChild(materialsList);
+    }
+
+    if(Array.isArray(item.steps) && item.steps.length){
+      const stepsHeading = document.createElement('h3');
+      stepsHeading.textContent = 'Steps';
+      body.appendChild(stepsHeading);
+
+      const stepsList = document.createElement('ol');
+      item.steps.forEach(function(step){
+        const li = document.createElement('li');
+        li.textContent = step;
+        stepsList.appendChild(li);
+      });
+      body.appendChild(stepsList);
+    }
+
+    if(item.assessment){
+      const assessment = document.createElement('p');
+      const label = document.createElement('strong');
+      label.textContent = 'Assessment:';
+      assessment.appendChild(label);
+      assessment.appendChild(document.createTextNode(' ' + item.assessment));
+      body.appendChild(assessment);
+    }
+
+    if(Array.isArray(item.links) && item.links.length){
+      const linksWrap = document.createElement('div');
+      const headingEl = document.createElement('h3');
+      headingEl.textContent = 'Links';
+      linksWrap.appendChild(headingEl);
+
+      const list = document.createElement('div');
+      list.className = 'links-list';
+      item.links.forEach(function(link){
+        if(!link || !link.url){ return; }
+        const anchor = document.createElement('a');
+        const labelText = link.label || link.url;
+        anchor.href = link.url;
+        anchor.target = '_blank';
+        anchor.rel = 'noopener noreferrer';
+        anchor.innerHTML = labelText + '<span class="outbound-icon" aria-hidden="true">↗</span><span class="sr-only"> opens in a new tab</span>';
+        list.appendChild(anchor);
+      });
+      linksWrap.appendChild(list);
+      body.appendChild(linksWrap);
+    }
+
+    if(state.teacherMode && Array.isArray(item.teacherTips) && item.teacherTips.length){
+      const tipsWrap = document.createElement('div');
+      tipsWrap.className = 'teacher-tip';
+      const headingEl = document.createElement('strong');
+      headingEl.textContent = 'Teacher Tips';
+      tipsWrap.appendChild(headingEl);
+
+      const tipsList = document.createElement('ul');
+      item.teacherTips.forEach(function(tip){
+        const li = document.createElement('li');
+        li.textContent = tip;
+        tipsList.appendChild(li);
+      });
+      tipsWrap.appendChild(tipsList);
+      body.appendChild(tipsWrap);
+    }
+
+    return body;
+  }
+
+  function createWeekLabel(week){
+    const container = document.createElement('div');
+    container.className = 'week-label';
+    container.setAttribute('role', 'heading');
+    container.setAttribute('aria-level', '3');
+    const icon = document.createElement('span');
+    icon.className = 'icon';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.textContent = '🗓️';
+    container.appendChild(icon);
+    container.appendChild(document.createTextNode('Week ' + week));
+    return container;
+  }
+
+  function toggleFavorite(id){
+    const index = state.favorites.indexOf(id);
+    if(index === -1){
+      state.favorites.push(id);
+    } else {
+      state.favorites.splice(index, 1);
+    }
+    setStoredArray(STORAGE_KEYS.favorites, state.favorites);
+    updateFavoritesButton();
+  }
+
+  function toggleSelected(id, isChecked){
+    const index = state.selected.indexOf(id);
+    if(isChecked && index === -1){
+      state.selected.push(id);
+    }
+    if(!isChecked && index > -1){
+      state.selected.splice(index, 1);
+    }
+    setStoredArray(STORAGE_KEYS.selected, state.selected);
+  }
+
+  function handlePrint(){
+    const items = getSelectedItems();
+    if(!items.length){
+      window.alert('Select at least one activity to print or export.');
+      return;
+    }
+    buildPrintArea(items);
+    document.body.classList.add('peo-printing');
+    printArea.setAttribute('aria-hidden', 'false');
+    window.print();
+    setTimeout(cleanUpPrintMode, 1000);
+  }
+
+  function getSelectedItems(){
+    const selectedSet = new Set(state.selected);
+    const items = state.items.filter(function(item){
+      return selectedSet.has(item.id);
+    });
+    items.sort(function(a, b){
+      if(a.week !== b.week){ return a.week - b.week; }
+      if(a.lessonOrder !== b.lessonOrder){ return a.lessonOrder - b.lessonOrder; }
+      return a.title.localeCompare(b.title, undefined, { sensitivity: 'base' });
+    });
+    return items;
+  }
+
+  function buildPrintArea(items){
+    printArea.innerHTML = '';
+    const title = document.createElement('h1');
+    title.textContent = 'PEO Year 9 – Sequenced Activities';
+    printArea.appendChild(title);
+
+    const formatter = new Intl.DateTimeFormat('en-AU', { dateStyle: 'full', timeZone: 'Australia/Melbourne' });
+    const meta = document.createElement('p');
+    meta.className = 'print-meta';
+    meta.textContent = 'Printed: ' + formatter.format(new Date()) + ' – PEO Y9 Sequenced';
+    printArea.appendChild(meta);
+
+    items.forEach(function(item){
+      const container = document.createElement('article');
+      container.className = 'peo-print-activity';
+
+      const headingEl = document.createElement('h2');
+      headingEl.textContent = item.title;
+      container.appendChild(headingEl);
+
+      const metaLine = document.createElement('p');
+      let details = 'Week ' + item.week + ' · Lesson ' + item.lessonOrder;
+      if(item.duration){ details += ' • Duration: ' + item.duration; }
+      details += ' • Topic: ' + item.topicTitle;
+      if(item.grouping){ details += ' • Grouping: ' + item.grouping; }
+      metaLine.textContent = details;
+      container.appendChild(metaLine);
+
+      if(item.visibleLearning && item.visibleLearning.learningIntentions){
+        const liHeading = document.createElement('h3');
+        liHeading.textContent = 'Learning Intentions';
+        container.appendChild(liHeading);
+
+        const liParagraph = document.createElement('p');
+        liParagraph.textContent = item.visibleLearning.learningIntentions;
+        container.appendChild(liParagraph);
+      }
+
+      if(item.visibleLearning && Array.isArray(item.visibleLearning.successCriteria) && item.visibleLearning.successCriteria.length){
+        const scHeading = document.createElement('h3');
+        scHeading.textContent = 'Success Criteria';
+        container.appendChild(scHeading);
+
+        const scList = document.createElement('ul');
+        item.visibleLearning.successCriteria.forEach(function(criteria){
+          const li = document.createElement('li');
+          li.textContent = criteria;
+          scList.appendChild(li);
+        });
+        container.appendChild(scList);
+      }
+
+      if(Array.isArray(item.objectives) && item.objectives.length){
+        const objectivesHeading = document.createElement('h3');
+        objectivesHeading.textContent = 'Objectives';
+        container.appendChild(objectivesHeading);
+
+        const objectivesList = document.createElement('ul');
+        item.objectives.forEach(function(obj){
+          const li = document.createElement('li');
+          li.textContent = obj;
+          objectivesList.appendChild(li);
+        });
+        container.appendChild(objectivesList);
+      }
+
+      if(Array.isArray(item.materials) && item.materials.length){
+        const materialsHeading = document.createElement('h3');
+        materialsHeading.textContent = 'Materials';
+        container.appendChild(materialsHeading);
+
+        const materialsList = document.createElement('ul');
+        item.materials.forEach(function(material){
+          const li = document.createElement('li');
+          li.textContent = material;
+          materialsList.appendChild(li);
+        });
+        container.appendChild(materialsList);
+      }
+
+      if(Array.isArray(item.steps) && item.steps.length){
+        const stepsHeading = document.createElement('h3');
+        stepsHeading.textContent = 'Steps';
+        container.appendChild(stepsHeading);
+
+        const stepsList = document.createElement('ol');
+        item.steps.forEach(function(step){
+          const li = document.createElement('li');
+          li.textContent = step;
+          stepsList.appendChild(li);
+        });
+        container.appendChild(stepsList);
+      }
+
+      if(item.assessment){
+        const assessment = document.createElement('p');
+        const label = document.createElement('strong');
+        label.textContent = 'Assessment:';
+        assessment.appendChild(label);
+        assessment.appendChild(document.createTextNode(' ' + item.assessment));
+        container.appendChild(assessment);
+      }
+
+      if(Array.isArray(item.links) && item.links.length){
+        const linksHeading = document.createElement('h3');
+        linksHeading.textContent = 'Links';
+        container.appendChild(linksHeading);
+
+        const list = document.createElement('ul');
+        item.links.forEach(function(link){
+          if(!link || !link.url){ return; }
+          const li = document.createElement('li');
+          const anchor = document.createElement('a');
+          anchor.href = link.url;
+          anchor.textContent = link.label || link.url;
+          li.appendChild(anchor);
+          list.appendChild(li);
+        });
+        container.appendChild(list);
+      }
+
+      if(state.teacherMode && Array.isArray(item.teacherTips) && item.teacherTips.length){
+        const tipsHeading = document.createElement('h3');
+        tipsHeading.textContent = 'Teacher Tips';
+        container.appendChild(tipsHeading);
+
+        const tipsList = document.createElement('ul');
+        item.teacherTips.forEach(function(tip){
+          const li = document.createElement('li');
+          li.textContent = tip;
+          tipsList.appendChild(li);
+        });
+        container.appendChild(tipsList);
+      }
+
+      printArea.appendChild(container);
+    });
+  }
+
+  function cleanUpPrintMode(){
+    document.body.classList.remove('peo-printing');
+    if(printArea){
+      printArea.setAttribute('aria-hidden', 'true');
+      printArea.innerHTML = '';
+    }
+  }
+
+  function pruneStoredIds(){
+    const validIds = new Set(state.items.map(function(item){ return item.id; }));
+    state.favorites = state.favorites.filter(function(id){ return validIds.has(id); });
+    state.selected = state.selected.filter(function(id){ return validIds.has(id); });
+    setStoredArray(STORAGE_KEYS.favorites, state.favorites);
+    setStoredArray(STORAGE_KEYS.selected, state.selected);
+  }
+
+  function updateTeacherModeButton(){
+    if(!teacherModeBtn){ return; }
+    teacherModeBtn.setAttribute('aria-pressed', state.teacherMode ? 'true' : 'false');
+    teacherModeBtn.textContent = state.teacherMode ? 'Teacher Mode: On' : 'Teacher Mode: Off';
+  }
+
+  function updateFavoritesButton(){
+    if(!favoritesBtn){ return; }
+    favoritesBtn.setAttribute('aria-pressed', state.favoritesOnly ? 'true' : 'false');
+    favoritesBtn.textContent = state.favoritesOnly ? 'Show Favourites: On' : 'Show Favourites';
+  }
+
+  function isFavorite(id){
+    return state.favorites.indexOf(id) > -1;
+  }
+
+  function isSelected(id){
+    return state.selected.indexOf(id) > -1;
+  }
+
+  function focusHeadingForHash(){
+    if(window.location.hash !== '#peo-y9-sequenced' || !heading){ return; }
+    if(typeof heading.focus === 'function'){
+      heading.focus({ preventScroll: true });
+    }
+    heading.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' });
+  }
+
+  function debounce(fn, wait){
+    let timeout;
+    return function(){
+      const context = this;
+      const args = arguments;
+      clearTimeout(timeout);
+      timeout = setTimeout(function(){
+        fn.apply(context, args);
+      }, wait);
+    };
+  }
+
+  function getStoredBoolean(key, fallback){
+    try {
+      const value = localStorage.getItem(key);
+      if(value === null){ return fallback; }
+      return value === 'true';
+    } catch(e){
+      return fallback;
+    }
+  }
+
+  function setStoredBoolean(key, value){
+    try {
+      localStorage.setItem(key, value ? 'true' : 'false');
+    } catch(e){}
+  }
+
+  function getStoredArray(key){
+    try {
+      const value = localStorage.getItem(key);
+      if(!value){ return []; }
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch(e){
+      return [];
+    }
+  }
+
+  function setStoredArray(key, arr){
+    try {
+      localStorage.setItem(key, JSON.stringify(arr));
+    } catch(e){}
+  }
+
+  setTimeout(focusHeadingForHash, 150);
+})();


### PR DESCRIPTION
## Summary
- add a PEO Year 9 sequenced section to the main page with navigation, filters, and export controls
- seed the sequenced activities JSON with week-by-week learning data
- implement rendering logic, persistence, and print support for the sequenced planner and extend shared styling

## Testing
- python -m json.tool data/peo-y9-sequenced.json


------
https://chatgpt.com/codex/tasks/task_e_68c8c6166e7c832499a68f95151531ee