### PR TITLE
feat: add view toggle to switch between 8-week plan and Dispositions

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -38,6 +38,9 @@
         <button id="loadSaPresetBtn" class="rounded-xl px-3 py-2 bg-white border border-amber-400 text-amber-700 focus-ring" title="Load SA Equal Before the Law?">
           Load SA “Equal Before the Law?”
         </button>
+        <button id="toggleViewBtn" class="rounded-xl px-3 py-2 bg-white border border-amber-400 text-amber-700 focus-ring" aria-pressed="false">
+          Switch to Dispositions
+        </button>
         <button id="bulkResBtn"
           class="rounded-xl px-3 py-2 bg-white border border-sky-400 text-sky-700 focus-ring"
           title="Bulk update Resources">
@@ -59,59 +62,79 @@
     </nav>
   </header>
 
-  <main id="mainContent" class="max-w-6xl mx-auto p-4 space-y-6">
-    <!-- Unit Details Card -->
-    <section class="bg-white/80 backdrop-blur rounded-2xl shadow p-5 border border-slate-200">
-      <div class="flex items-start justify-between gap-4">
-        <h2 class="text-xl font-semibold tracking-tight">Unit Details</h2>
-        <div class="flex items-center gap-3 no-print">
-          <div class="inline-flex rounded-2xl border border-slate-300 bg-slate-100 p-1" id="curriculumToggle" role="tablist" aria-label="Curriculum toggle">
-            <button data-mode="SA" class="px-3 py-1.5 text-sm rounded-xl bg-white shadow font-semibold" role="tab" aria-selected="true">SA</button>
-            <button data-mode="ACARA" class="px-3 py-1.5 text-sm rounded-xl text-slate-600" role="tab" aria-selected="false">ACARA</button>
+  <main id="mainContent" class="max-w-6xl mx-auto p-4">
+    <section id="weekView" class="space-y-6">
+      <!-- Unit Details Card -->
+      <section class="bg-white/80 backdrop-blur rounded-2xl shadow p-5 border border-slate-200">
+        <div class="flex items-start justify-between gap-4">
+          <h2 class="text-xl font-semibold tracking-tight">Unit Details</h2>
+          <div class="flex items-center gap-3 no-print">
+            <div class="inline-flex rounded-2xl border border-slate-300 bg-slate-100 p-1" id="curriculumToggle" role="tablist" aria-label="Curriculum toggle">
+              <button data-mode="SA" class="px-3 py-1.5 text-sm rounded-xl bg-white shadow font-semibold" role="tab" aria-selected="true">SA</button>
+              <button data-mode="ACARA" class="px-3 py-1.5 text-sm rounded-xl text-slate-600" role="tab" aria-selected="false">ACARA</button>
+            </div>
+            <button id="quickEdit" class="rounded-xl px-3 py-1.5 bg-slate-900 text-white focus-ring" title="Quick edit">Quick Edit</button>
           </div>
-          <button id="quickEdit" class="rounded-xl px-3 py-1.5 bg-slate-900 text-white focus-ring" title="Quick edit">Quick Edit</button>
         </div>
-      </div>
-      <div class="mt-3 grid md:grid-cols-2 gap-6" id="unitMeta" aria-live="polite"></div>
+        <div class="mt-3 grid md:grid-cols-2 gap-6" id="unitMeta" aria-live="polite"></div>
+      </section>
+
+      <!-- Tabs -->
+      <nav class="flex flex-wrap gap-2 no-print" id="tabs" role="tablist" aria-label="Sections"></nav>
+
+      <!-- Tab Panels -->
+      <div id="panel" aria-live="polite"></div>
+
+      <section id="peo-y9" class="section">
+        <h2 tabindex="-1">PEO Year 9 Activities</h2>
+
+        <!-- Controls -->
+        <div class="controls">
+          <input id="searchActivities" type="search" placeholder="Search activities, tags, objectives…" aria-label="Search activities" />
+          <select id="filterTopic" aria-label="Filter by topic"></select>
+          <select id="filterType" aria-label="Filter by type"></select>
+          <button id="filterFavorites" aria-pressed="false">Favorites</button>
+          <button id="toggleTeacherMode" aria-pressed="false">Teacher Mode: Off</button>
+          <button id="printSelected">Print/Export Selected</button>
+        </div>
+
+        <!-- Rendered cards go here -->
+        <div id="activitiesGrid" class="grid"></div>
+      </section>
+
+      <section id="peo-y9-sequenced" class="section">
+        <h2 tabindex="-1">PEO Year 9 – Sequenced Activities</h2>
+
+        <div class="controls">
+          <label class="sr-only" for="sequenceWeek">Jump to week</label>
+          <select id="sequenceWeek"></select>
+
+          <input id="searchSeq" type="search" placeholder="Search activities, aims, tags…" aria-label="Search activities" />
+          <button id="toggleTeacherMode2" aria-pressed="false">Teacher Mode: Off</button>
+          <button id="showFavorites2" aria-pressed="false">Show Favourites</button>
+          <button id="printSelected2">Print/Export Selected</button>
+        </div>
+
+        <div id="seqGrid" class="grid"></div>
+      </section>
     </section>
 
-    <!-- Tabs -->
-    <nav class="flex flex-wrap gap-2 no-print" id="tabs" role="tablist" aria-label="Sections"></nav>
+    <section id="dispView" class="space-y-6" hidden aria-hidden="true">
+      <section class="bg-white/80 backdrop-blur rounded-2xl shadow p-5 border border-slate-200">
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <h2 class="text-xl font-semibold tracking-tight">Dispositions Focus</h2>
+            <p id="dispositionsUnitTitle" class="text-sm text-slate-600"></p>
+          </div>
+          <div id="dispositionsMeta" class="text-right text-xs text-slate-500"></div>
+        </div>
+        <div class="mt-4 grid gap-4 md:grid-cols-2" id="dispositionsGrid" aria-live="polite"></div>
+      </section>
 
-    <!-- Tab Panels -->
-    <div id="panel" aria-live="polite"></div>
-
-    <section id="peo-y9" class="section">
-      <h2 tabindex="-1">PEO Year 9 Activities</h2>
-
-      <!-- Controls -->
-      <div class="controls">
-        <input id="searchActivities" type="search" placeholder="Search activities, tags, objectives…" aria-label="Search activities" />
-        <select id="filterTopic" aria-label="Filter by topic"></select>
-        <select id="filterType" aria-label="Filter by type"></select>
-        <button id="filterFavorites" aria-pressed="false">Favorites</button>
-        <button id="toggleTeacherMode" aria-pressed="false">Teacher Mode: Off</button>
-        <button id="printSelected">Print/Export Selected</button>
-      </div>
-
-      <!-- Rendered cards go here -->
-      <div id="activitiesGrid" class="grid"></div>
-    </section>
-
-    <section id="peo-y9-sequenced" class="section">
-      <h2 tabindex="-1">PEO Year 9 – Sequenced Activities</h2>
-
-      <div class="controls">
-        <label class="sr-only" for="sequenceWeek">Jump to week</label>
-        <select id="sequenceWeek"></select>
-
-        <input id="searchSeq" type="search" placeholder="Search activities, aims, tags…" aria-label="Search activities" />
-        <button id="toggleTeacherMode2" aria-pressed="false">Teacher Mode: Off</button>
-        <button id="showFavorites2" aria-pressed="false">Show Favourites</button>
-        <button id="printSelected2">Print/Export Selected</button>
-      </div>
-
-      <div id="seqGrid" class="grid"></div>
+      <section class="bg-white/80 backdrop-blur rounded-2xl shadow p-5 border border-slate-200">
+        <h2 class="text-xl font-semibold tracking-tight">Observation prompts</h2>
+        <div class="mt-3 prose prose-slate max-w-none" id="dispositionsPrompts"></div>
+      </section>
     </section>
   </main>
 
@@ -519,6 +542,7 @@ function render(){
   });
   var lastTab = ssGet('yr9-tab', 'Overview');
   selectTab(lastTab);
+  renderDispositionsView();
 }
 
 function editMetaField(label,key,val){
@@ -644,6 +668,69 @@ function renderResources(root){
     <li>Embed digital tools students enjoy (Canva, Google Slides, Minecraft civic-space builds).</li>\
     <li>Establish discussion norms (respect, evidence, turn-taking) to cultivate principled discourse.</li>\
   </ul>');
+}
+
+function renderDispositionsView(data){
+  var grid = document.getElementById('dispositionsGrid');
+  if(!grid){ return; }
+
+  var prompts = document.getElementById('dispositionsPrompts');
+  var unitTitle = document.getElementById('dispositionsUnitTitle');
+  var metaEl = document.getElementById('dispositionsMeta');
+
+  var metaSource = plan && plan.meta ? Object.assign({}, plan.meta) : {};
+  if(data && data.meta){
+    metaSource = Object.assign(metaSource, data.meta);
+  }
+
+  if(unitTitle){
+    var titleBits = [];
+    if(metaSource.title){ titleBits.push(metaSource.title); }
+    if(metaSource.duration){ titleBits.push(metaSource.duration); }
+    unitTitle.textContent = titleBits.join(' • ');
+  }
+
+  if(metaEl){
+    var metaBits = [];
+    if(metaSource.author){ metaBits.push('Author: ' + metaSource.author); }
+    if(metaSource.lastUpdated){ metaBits.push('Updated ' + metaSource.lastUpdated); }
+    metaEl.textContent = metaBits.join(' • ');
+  }
+
+  var dispositionsData;
+  if(Array.isArray(data)){
+    dispositionsData = data.slice();
+  } else if(data && Array.isArray(data.dispositions)){
+    dispositionsData = data.dispositions.slice();
+  } else {
+    dispositionsData = (plan && Array.isArray(plan.dispositions)) ? plan.dispositions.slice() : [];
+  }
+
+  if(!dispositionsData.length){
+    grid.innerHTML = '<p class="text-sm text-slate-600">No dispositions available yet.</p>';
+  } else {
+    grid.innerHTML = dispositionsData.map(function(item){
+      var name = item && item.name ? escapeHtml(item.name) : 'Disposition';
+      var notes = item && item.notes ? escapeHtml(item.notes) : 'Add notes to describe what this looks like in practice.';
+      return '<article class="rounded-2xl border border-slate-200 bg-white/90 p-4 shadow-sm h-full">'
+        + '<h3 class="text-lg font-semibold text-slate-900">' + name + '</h3>'
+        + '<p class="text-sm text-slate-600 mt-2">' + notes + '</p>'
+        + '</article>';
+    }).join('');
+  }
+
+  if(prompts){
+    if(!dispositionsData.length){
+      prompts.innerHTML = '<p class="text-sm text-slate-600">Use the 8-week plan view to add or import dispositions, then return here to capture evidence.</p>';
+    } else {
+      var promptItems = dispositionsData.map(function(item){
+        var name = item && item.name ? escapeHtml(item.name) : 'This disposition';
+        return '<li><span class="font-medium">' + name + ':</span> Where did students demonstrate this disposition? Collect quotes, artifacts or reflections as evidence.</li>';
+      });
+      promptItems.push('<li>Plan upcoming learning experiences that give students another opportunity to practise these dispositions.</li>');
+      prompts.innerHTML = '<ul class="list-disc pl-5 space-y-2">' + promptItems.join('') + '</ul>';
+    }
+  }
 }
 
 function card(title, inner){
@@ -808,6 +895,23 @@ function runSelfTests(){
 // Initial render + tests
 render();
 runSelfTests();
+
+window.render8Week = function(data){
+  if(data && typeof data === 'object' && !Array.isArray(data) && data.meta && data.sequence){
+    try {
+      plan = deepClone(data);
+      saveState();
+    } catch (err) {
+      console.error('Unable to apply provided 8-week data', err);
+    }
+  }
+  render();
+};
+
+window.renderDispositions = function(data){
+  renderDispositionsView(data);
+};
 </script>
+<script src="js/view-toggle.js" defer></script>
 </body>
 </html>

--- a/js/view-toggle.js
+++ b/js/view-toggle.js
@@ -1,0 +1,103 @@
+(function(){
+  const VIEW_KEY = 'y9_view'; // localStorage key
+
+  // Helper: query
+  const $ = (s, r=document) => r.querySelector(s);
+
+  // Read initial view from ?view= or localStorage, default to 8week
+  function getInitialView() {
+    try {
+      const url = new URL(location.href);
+      const q = (url.searchParams.get('view') || '').toLowerCase();
+      if (q === '8week' || q === 'dispositions') return q;
+    } catch {}
+    try {
+      const saved = localStorage.getItem(VIEW_KEY);
+      if (saved === '8week' || saved === 'dispositions') return saved;
+    } catch {}
+    return '8week';
+  }
+
+  // Show/hide sections with accessibility attributes
+  function setSectionVisible(el, on) {
+    if (!el) return;
+    el.hidden = !on;
+    el.setAttribute('aria-hidden', String(!on));
+  }
+
+  async function fetchJSON(path) {
+    const res = await fetch(path, { cache: 'no-store' });
+    if (!res.ok) throw new Error('Fetch failed: ' + path);
+    return res.json();
+  }
+
+  // Optionally (re)render each view if hooks exist
+  async function renderIfAvailable(view) {
+    if (view === '8week') {
+      if (typeof window.render8Week === 'function') {
+        if (!window.DATA_8WEEK && window.DATA_8WEEK_PATH) {
+          try { window.DATA_8WEEK = await fetchJSON(window.DATA_8WEEK_PATH); } catch {}
+        }
+        try { window.render8Week(window.DATA_8WEEK); } catch {}
+      }
+    } else {
+      if (typeof window.renderDispositions === 'function') {
+        if (!window.DATA_DISP && window.DATA_DISP_PATH) {
+          try { window.DATA_DISP = await fetchJSON(window.DATA_DISP_PATH); } catch {}
+        }
+        try { window.renderDispositions(window.DATA_DISP); } catch {}
+      }
+    }
+  }
+
+  async function applyView(v) {
+    const week = $('#weekView');
+    const disp  = $('#dispView');
+    const btn  = $('#toggleViewBtn');
+
+    setSectionVisible(week, v === '8week');
+    setSectionVisible(disp,  v === 'dispositions');
+
+    if (btn) {
+      btn.textContent = (v === '8week') ? 'Switch to Dispositions' : 'Switch to 8-Week Plan';
+      btn.setAttribute('aria-pressed', String(v === 'dispositions'));
+    }
+
+    // optional: (re)render for the active view
+    await renderIfAvailable(v);
+  }
+
+  function setUrlParam(view) {
+    try {
+      const url = new URL(location.href);
+      url.searchParams.set('view', view);
+      history.replaceState(null, '', url);
+    } catch {}
+  }
+
+  async function init() {
+    const btn = $('#toggleViewBtn');
+    if (!$('#weekView') || !$('#dispView') || !btn) return; // graceful no-op if structure missing
+
+    let view = getInitialView();
+    await applyView(view);
+
+    btn.addEventListener('click', async () => {
+      view = (view === '8week') ? 'dispositions' : '8week';
+      try { localStorage.setItem(VIEW_KEY, view); } catch {}
+      setUrlParam(view);
+      await applyView(view);
+    });
+  }
+
+  // Expose optional paths if you plan to lazy-load JSON
+  // Example (set these in your page script elsewhere):
+  // window.DATA_8WEEK_PATH = 'data/8week.json';
+  // window.DATA_DISP_PATH  = 'data/dispositions.json';
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- add a Dispositions toggle button alongside the existing preset controls
- wrap the existing 8-week experience and new Dispositions layout in dedicated sections for switching
- render dispositions-specific content and wire up a reusable toggle script to handle URL/localStorage state

## Testing
- Manual Playwright verification of view toggle

------
https://chatgpt.com/codex/tasks/task_e_68c8d1c128a8832481956b7e30bb8a7e