### PR TITLE
feat(ui): apply Australian green & gold theme with accessible contrast

### DIFF
--- a/css/peo-y9.css
+++ b/css/peo-y9.css
@@ -1,14 +1,157 @@
+:root {
+  /* Australian Green & Gold (accessible set) */
+  --green-600: #006b3f;
+  --green-700: #004d2b;
+  --green-300: #35a56b;
+  --gold-500: #ffcd00;
+  --gold-600: #e6b800;
+  --ink: #0f172a;
+  --ink-2: #1a1a1a;
+  --bg: #ffffff;
+  --muted: #475569;
+  --border: #e2e8f0;
+  --ring: #ffcd00;
+}
+
 .skip-link {
   position: absolute;
   top: -999px;
   left: 0.75rem;
   padding: 0.75rem 1rem;
-  background-color: #0f172a;
+  background-color: var(--ink);
   color: #fff;
   z-index: 1000;
   border-radius: 0.75rem;
   text-decoration: none;
   box-shadow: 0 10px 25px -15px rgba(15, 23, 42, 0.6);
+}
+
+header.site-header {
+  background: var(--green-700);
+  color: #fff;
+  border-bottom: 3px solid var(--gold-500);
+}
+
+header.site-header h1,
+header.site-header .lead {
+  color: #fff;
+}
+
+header.site-header nav {
+  background: rgba(0, 77, 43, 0.92);
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+header.site-header nav a {
+  color: #fff;
+}
+
+header.site-header nav a:hover {
+  color: var(--gold-500);
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  border-radius: 0.75rem;
+  padding: 0.55rem 1rem;
+  font-weight: 600;
+  line-height: 1.25;
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-primary {
+  background: var(--gold-500);
+  color: var(--ink-2);
+  border-color: var(--gold-500);
+}
+
+.btn-primary:hover {
+  background: var(--gold-600);
+  border-color: var(--gold-600);
+}
+
+.btn-secondary {
+  background: var(--green-600);
+  color: #fff;
+  border-color: var(--green-600);
+}
+
+.btn-secondary:hover {
+  background: var(--green-700);
+  border-color: var(--green-700);
+}
+
+.btn-outline {
+  background: transparent;
+  color: var(--green-700);
+  border-color: var(--green-700);
+}
+
+.btn-outline:hover {
+  background: rgba(53, 165, 107, 0.15);
+  border-color: var(--green-300);
+}
+
+.tab {
+  border: 1px solid var(--green-700);
+  color: var(--green-700);
+  background: transparent;
+}
+
+.tab:hover {
+  background: rgba(53, 165, 107, 0.12);
+}
+
+.tab[aria-selected="true"] {
+  background: var(--gold-500);
+  color: var(--ink-2);
+  border-color: var(--gold-500);
+}
+
+.chip {
+  background: rgba(255, 205, 0, 0.12);
+  border: 1px solid var(--gold-500);
+  color: var(--ink);
+}
+
+a {
+  color: var(--green-700);
+}
+
+a:hover {
+  color: var(--green-600);
+}
+
+.card {
+  border: 1px solid var(--border);
+}
+
+.card header {
+  border-bottom: 1px solid var(--border);
+}
+
+:focus-visible {
+  outline: 3px solid var(--ring);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.bg-gold,
+.alert-gold {
+  background: var(--gold-500);
+  color: var(--ink-2);
+}
+
+.bg-green {
+  background: var(--green-700);
+  color: #fff;
 }
 
 .skip-link:focus {
@@ -31,7 +174,7 @@
   background-color: rgba(255, 255, 255, 0.9);
   backdrop-filter: blur(8px);
   border-radius: 1.25rem;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border);
   box-shadow: 0 18px 45px -30px rgba(15, 23, 42, 0.45);
   padding: 1.75rem 1.5rem 2rem;
 }
@@ -39,7 +182,7 @@
 .section h2 {
   font-size: clamp(1.5rem, 2vw, 1.85rem);
   font-weight: 700;
-  color: #0f172a;
+  color: var(--ink);
   margin-bottom: 1.5rem;
 }
 
@@ -53,47 +196,48 @@
 
 .controls input[type="search"],
 .controls select {
-  border: 1px solid #cbd5f5;
+  border: 1px solid var(--border);
   border-radius: 0.75rem;
   padding: 0.55rem 0.9rem;
   min-width: 12rem;
-  background-color: #fff;
-  color: #0f172a;
+  background-color: var(--bg);
+  color: var(--ink);
   box-shadow: inset 0 1px 2px rgba(148, 163, 184, 0.2);
 }
 
 .controls input[type="search"]:focus-visible,
 .controls select:focus-visible {
-  outline: 3px solid rgba(37, 99, 235, 0.4);
+  outline: 3px solid var(--ring);
   outline-offset: 2px;
 }
 
 .controls button {
   border-radius: 0.75rem;
-  border: 1px solid #cbd5f5;
-  background-color: #f8fafc;
+  border: 1px solid var(--border);
+  background-color: rgba(0, 107, 63, 0.08);
   padding: 0.55rem 1rem;
   font-weight: 600;
-  color: #1e293b;
+  color: var(--green-700);
   cursor: pointer;
   transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
 .controls button:hover,
 .controls button:focus-visible {
-  background-color: #e0f2fe;
+  background-color: rgba(53, 165, 107, 0.18);
+  border-color: var(--green-300);
 }
 
 .controls button:focus-visible {
-  outline: 3px solid rgba(37, 99, 235, 0.4);
+  outline: 3px solid var(--ring);
   outline-offset: 2px;
 }
 
 .controls button[aria-pressed="true"],
 .controls button.is-on {
-  background-color: #0f172a;
+  background-color: var(--green-700);
   color: #fff;
-  border-color: #0f172a;
+  border-color: var(--green-700);
 }
 
 .grid {
@@ -122,7 +266,7 @@
 }
 
 .sequence-card {
-  border-left: 4px solid var(--sequence-accent, #334155);
+  border-left: 4px solid var(--sequence-accent, var(--green-700));
 }
 
 .sequence-header {
@@ -150,8 +294,9 @@
   padding: 0.25rem 0.65rem;
   font-size: 0.75rem;
   font-weight: 600;
-  background-color: rgba(15, 23, 42, 0.08);
-  color: #1e293b;
+  background-color: rgba(255, 205, 0, 0.12);
+  color: var(--ink);
+  border: 1px solid rgba(255, 205, 0, 0.4);
 }
 
 .sequence-chip .icon {
@@ -159,8 +304,9 @@
 }
 
 .sequence-chip--week {
-  background-color: rgba(59, 130, 246, 0.15);
-  color: #1d4ed8;
+  background-color: rgba(0, 107, 63, 0.12);
+  color: var(--green-700);
+  border-color: rgba(0, 107, 63, 0.35);
 }
 
 .sequence-topic {
@@ -183,17 +329,17 @@
   align-items: center;
   gap: 0.35rem;
   font-size: 0.8rem;
-  color: #334155;
+  color: var(--muted);
 }
 
 .sequence-select input[type="checkbox"] {
   width: 1rem;
   height: 1rem;
-  accent-color: var(--sequence-accent, #0f172a);
+  accent-color: var(--sequence-accent, var(--green-700));
 }
 
 .sequence-body {
-  border-top: 1px solid rgba(148, 163, 184, 0.25);
+  border-top: 1px solid var(--border);
   margin-top: 0.75rem;
   padding-top: 0.75rem;
 }
@@ -203,8 +349,8 @@
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  background-color: rgba(15, 23, 42, 0.05);
-  color: #0f172a;
+  background-color: rgba(0, 107, 63, 0.08);
+  color: var(--green-700);
   border-radius: 0.75rem;
   padding: 0.45rem 0.85rem;
   font-weight: 700;
@@ -232,14 +378,14 @@
 }
 
 .activity-toggle:focus-visible {
-  outline: 3px solid rgba(37, 99, 235, 0.8);
+  outline: 3px solid var(--ring);
   outline-offset: 3px;
 }
 
 .activity-title {
   font-size: 1.1rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--ink);
   display: block;
 }
 
@@ -249,7 +395,7 @@
   gap: 0.35rem;
   margin-top: 0.6rem;
   font-size: 0.85rem;
-  color: #475569;
+  color: var(--muted);
   align-items: center;
 }
 
@@ -275,8 +421,8 @@
   justify-content: center;
   border-radius: 999px;
   padding: 0.2rem 0.6rem;
-  background-color: #e2e8f0;
-  color: #1e293b;
+  background-color: rgba(0, 107, 63, 0.12);
+  color: var(--green-700);
   font-size: 0.7rem;
   font-weight: 600;
   text-transform: uppercase;
@@ -284,8 +430,8 @@
 }
 
 .duration-pill {
-  background-color: #cbd5f5;
-  color: #1e293b;
+  background-color: rgba(255, 205, 0, 0.18);
+  color: var(--ink-2);
   border-radius: 999px;
   padding: 0.2rem 0.6rem;
   font-size: 0.75rem;
@@ -294,9 +440,9 @@
 
 .favorite-btn {
   align-self: flex-start;
-  background: none;
-  border: none;
-  color: #fbbf24;
+  background-color: rgba(255, 205, 0, 0.15);
+  border: 1px solid rgba(255, 205, 0, 0.4);
+  color: var(--ink);
   font-size: 0.95rem;
   font-weight: 700;
   padding: 0.4rem 0.75rem;
@@ -312,8 +458,8 @@
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  background-color: rgba(251, 191, 36, 0.18);
-  color: #b45309;
+  background-color: rgba(255, 205, 0, 0.18);
+  color: var(--ink-2);
   border-radius: 999px;
   padding: 0.15rem 0.55rem;
   font-size: 0.75rem;
@@ -322,7 +468,7 @@
 
 .grouping-label {
   font-size: 0.85rem;
-  color: #475569;
+  color: var(--muted);
   font-weight: 600;
 }
 
@@ -332,15 +478,17 @@
 
 .favorite-btn:hover,
 .favorite-btn:focus-visible {
-  background-color: rgba(251, 191, 36, 0.16);
+  background-color: rgba(255, 205, 0, 0.28);
 }
 
 .favorite-btn[aria-pressed="true"] {
-  color: #b45309;
+  background-color: var(--gold-500);
+  border-color: var(--gold-500);
+  color: var(--ink-2);
 }
 
 .favorite-btn:focus-visible {
-  outline: 3px solid rgba(234, 179, 8, 0.6);
+  outline: 3px solid var(--ring);
   outline-offset: 2px;
 }
 
@@ -357,14 +505,14 @@
   align-items: center;
   gap: 0.4rem;
   font-size: 0.85rem;
-  color: #334155;
+  color: var(--muted);
   margin-left: auto;
 }
 
 .activity-body {
   padding: 0 1rem 1.25rem;
   font-size: 0.95rem;
-  color: #1e293b;
+  color: var(--ink);
 }
 
 .activity-body > * + * {
@@ -375,7 +523,7 @@
   font-size: 0.95rem;
   font-weight: 700;
   margin-bottom: 0.45rem;
-  color: #0f172a;
+  color: var(--ink);
 }
 
 .activity-body ul,
@@ -388,8 +536,8 @@
 }
 
 .teacher-tip {
-  border-left: 3px solid #0f172a;
-  background-color: rgba(30, 64, 175, 0.08);
+  border-left: 3px solid var(--green-700);
+  background-color: rgba(0, 107, 63, 0.12);
   padding: 0.65rem 0.75rem;
   border-radius: 0.75rem;
   font-size: 0.9rem;
@@ -407,13 +555,13 @@
 }
 
 .links-list a {
-  color: #1d4ed8;
+  color: var(--green-700);
   text-decoration: underline;
   font-weight: 600;
 }
 
 .links-list a:focus-visible {
-  outline: 3px solid rgba(29, 78, 216, 0.5);
+  outline: 3px solid var(--ring);
   outline-offset: 2px;
 }
 
@@ -437,8 +585,8 @@
 .empty-state {
   padding: 2rem;
   border-radius: 1rem;
-  background-color: rgba(226, 232, 240, 0.6);
-  color: #475569;
+  background-color: rgba(0, 107, 63, 0.08);
+  color: var(--muted);
   text-align: center;
   font-weight: 600;
 }

--- a/index.htm
+++ b/index.htm
@@ -9,8 +9,6 @@
   <script defer src="js/peo-y9.js"></script>
   <script defer src="js/peo-y9-sequenced.js"></script>
   <style>
-    :root{ --ring: 219 14% 28%; }
-    .focus-ring:focus{ outline: 2px solid hsl(var(--ring)); outline-offset: 2px; }
     @media print {
       header, nav.no-print, .no-print{ display:none !important }
       main{ padding:0 !important }
@@ -22,27 +20,27 @@
 <body class="min-h-screen bg-gradient-to-b from-slate-100 to-slate-200 text-slate-900">
   <a class="skip-link" href="#mainContent">Skip to content</a>
   <!-- Top Bar -->
-  <header class="sticky top-0 z-10 border-b border-slate-200 backdrop-blur bg-white/70">
+  <header class="site-header sticky top-0 z-10 border-b border-slate-200 backdrop-blur bg-white/70">
     <div class="max-w-6xl mx-auto px-4 py-4 flex flex-wrap items-center gap-4 justify-between">
       <div>
         <h1 id="title" class="text-2xl font-bold tracking-tight">Year 9 Civics & Citizenship – Healthy Democracy</h1>
-        <p id="subtitle" class="text-sm text-slate-600">How might a deeper understanding of living in a healthy democracy restore trust and foster civically minded students?</p>
+        <p id="subtitle" class="lead text-sm text-slate-600">How might a deeper understanding of living in a healthy democracy restore trust and foster civically minded students?</p>
       </div>
       <div class="flex items-center gap-2 no-print">
-        <button id="printBtn" class="rounded-xl px-3 py-2 bg-white border border-slate-300 focus-ring" title="Print">Print</button>
-        <button id="exportBtn" class="rounded-xl px-3 py-2 bg-white border border-slate-300 focus-ring" title="Export JSON">Export JSON</button>
-        <label class="rounded-xl px-3 py-2 bg-white border border-slate-300 focus-ring cursor-pointer" title="Import JSON">
+        <button id="printBtn" class="btn btn-outline focus-ring" title="Print">Print</button>
+        <button id="exportBtn" class="btn btn-outline focus-ring" title="Export JSON">Export JSON</button>
+        <label class="btn btn-outline focus-ring cursor-pointer" title="Import JSON">
           Import JSON
           <input id="importInput" type="file" accept="application/json" class="hidden" />
         </label>
-        <button id="loadSaPresetBtn" class="rounded-xl px-3 py-2 bg-white border border-amber-400 text-amber-700 focus-ring" title="Load SA Equal Before the Law?">
+        <button id="loadSaPresetBtn" class="btn btn-primary focus-ring" title="Load SA Equal Before the Law?">
           Load SA “Equal Before the Law?”
         </button>
-        <button id="toggleViewBtn" class="rounded-xl px-3 py-2 bg-white border border-amber-400 text-amber-700 focus-ring" aria-pressed="false">
+        <button id="toggleViewBtn" class="btn btn-primary focus-ring" aria-pressed="false">
           Switch to Dispositions
         </button>
         <button id="bulkResBtn"
-          class="rounded-xl px-3 py-2 bg-white border border-sky-400 text-sky-700 focus-ring"
+          class="btn btn-secondary focus-ring"
           title="Bulk update Resources">
           Update Resources
         </button>
@@ -70,10 +68,10 @@
           <h2 class="text-xl font-semibold tracking-tight">Unit Details</h2>
           <div class="flex items-center gap-3 no-print">
             <div class="inline-flex rounded-2xl border border-slate-300 bg-slate-100 p-1" id="curriculumToggle" role="tablist" aria-label="Curriculum toggle">
-              <button data-mode="SA" class="px-3 py-1.5 text-sm rounded-xl bg-white shadow font-semibold" role="tab" aria-selected="true">SA</button>
-              <button data-mode="ACARA" class="px-3 py-1.5 text-sm rounded-xl text-slate-600" role="tab" aria-selected="false">ACARA</button>
+              <button data-mode="SA" class="px-3 py-1.5 text-sm rounded-xl tab font-semibold shadow" role="tab" aria-selected="true">SA</button>
+              <button data-mode="ACARA" class="px-3 py-1.5 text-sm rounded-xl tab" role="tab" aria-selected="false">ACARA</button>
             </div>
-            <button id="quickEdit" class="rounded-xl px-3 py-1.5 bg-slate-900 text-white focus-ring" title="Quick edit">Quick Edit</button>
+            <button id="quickEdit" class="btn btn-secondary focus-ring" title="Quick edit">Quick Edit</button>
           </div>
         </div>
         <div class="mt-3 grid md:grid-cols-2 gap-6" id="unitMeta" aria-live="polite"></div>
@@ -97,7 +95,7 @@
             <button
               type="button"
               id="peoTab-activities"
-              class="px-4 py-2 text-sm font-semibold rounded-xl border bg-slate-900 text-white border-slate-900 shadow transition-colors focus-ring"
+              class="px-4 py-2 text-sm font-semibold rounded-xl border tab shadow transition-colors focus-ring"
               role="tab"
               aria-selected="true"
               aria-controls="peo-y9"
@@ -108,7 +106,7 @@
             <button
               type="button"
               id="peoTab-sequenced"
-              class="px-4 py-2 text-sm font-semibold rounded-xl border bg-white text-slate-700 border-slate-300 transition-colors focus-ring"
+              class="px-4 py-2 text-sm font-semibold rounded-xl border tab transition-colors focus-ring"
               role="tab"
               aria-selected="false"
               aria-controls="peo-y9-sequenced"
@@ -212,7 +210,7 @@ function notify(msg){
   if(!box){ box = document.createElement('div'); box.id='toasts'; box.className='fixed bottom-4 right-4 z-50 space-y-2'; document.body.appendChild(box); }
   var n = document.createElement('div');
   n.setAttribute('role','status');
-  n.className='rounded-xl bg-slate-900 text-white px-3 py-2 shadow';
+  n.className='rounded-xl bg-green px-3 py-2 shadow';
   n.textContent = msg;
   box.appendChild(n);
   setTimeout(function(){ if(n && n.parentNode) n.parentNode.removeChild(n); }, 3000);
@@ -237,8 +235,6 @@ function setupPeoActivitiesTabs(){
   if(!panels.length){ return; }
 
   var storageKey = 'peoY9.sectionTab';
-  var activeClasses = ['bg-slate-900','text-white','border-slate-900','shadow'];
-  var inactiveClasses = ['bg-white','text-slate-700','border-slate-300'];
   var tabNames = new Set(buttons.map(function(btn){ return btn.dataset.peoTab; }).filter(Boolean));
   if(tabNames.size === 0){ return; }
 
@@ -257,8 +253,8 @@ function setupPeoActivitiesTabs(){
   function applyButtonState(btn, isActive){
     btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
     btn.setAttribute('tabindex', isActive ? '0' : '-1');
-    activeClasses.forEach(function(cls){ btn.classList.toggle(cls, isActive); });
-    inactiveClasses.forEach(function(cls){ btn.classList.toggle(cls, !isActive); });
+    btn.classList.add('tab');
+    btn.classList.toggle('shadow', isActive);
   }
 
   function applyPanelState(panel, isActive){
@@ -753,15 +749,10 @@ function render(){
 
   // Curriculum toggle styling
   $$('#curriculumToggle button').forEach(function(btn){
-    if(btn.dataset.mode===plan.curriculumView){
-      btn.classList.add('bg-white','shadow','font-semibold');
-      btn.classList.remove('text-slate-600');
-      btn.setAttribute('aria-selected','true');
-    } else {
-      btn.classList.remove('bg-white','shadow','font-semibold');
-      btn.classList.add('text-slate-600');
-      btn.setAttribute('aria-selected','false');
-    }
+    var isActive = btn.dataset.mode === plan.curriculumView;
+    btn.classList.toggle('shadow', isActive);
+    btn.classList.toggle('font-semibold', isActive);
+    btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
   });
 
   // Tabs
@@ -771,7 +762,8 @@ function render(){
   tabs.forEach(function(t){
     var b=document.createElement('button');
     b.textContent=t; b.dataset.tab=t; b.setAttribute('role','tab');
-    b.className = 'px-4 py-2 rounded-xl border bg-white border-slate-300 focus-ring';
+    b.className = 'px-4 py-2 text-sm font-semibold rounded-xl border tab focus-ring';
+    b.setAttribute('aria-selected','false');
     tabsEl.appendChild(b);
   });
   var lastTab = ssGet('yr9-tab', 'Overview');
@@ -806,12 +798,10 @@ function selectTab(tab){
   ssSet('yr9-tab', tab);
   $$('#tabs button').forEach(function(b){
     if(b.dataset.tab===tab){
-      b.classList.remove('bg-white','border-slate-300');
-      b.classList.add('bg-slate-900','text-white','border-slate-900');
+      b.classList.add('shadow');
       b.setAttribute('aria-selected','true');
     } else {
-      b.classList.add('bg-white','border-slate-300');
-      b.classList.remove('bg-slate-900','text-white','border-slate-900');
+      b.classList.remove('shadow');
       b.setAttribute('aria-selected','false');
     }
   });
@@ -974,7 +964,7 @@ function card(title, inner){
 function listEditor(items, key, placeholder){
   var list = (items || []).map(function(t,i){ return '<li class="group flex items-start gap-2"><span class="flex-1">'+escapeHtml(t)+'</span><button data-del="'+i+'" class="opacity-0 group-hover:opacity-100 text-xs text-red-600">remove</button></li>'; }).join('');
   return '<ul class="list-disc pl-5 space-y-1" data-edit-key="'+key+'">'+ list +'</ul>\
-  <div class="mt-3 flex gap-2"><input class="flex-1 rounded-xl border border-slate-300 px-3 py-2" placeholder="'+escapeHtml(placeholder)+'" /><button class="rounded-xl px-3 py-2 bg-slate-900 text-white" data-add="1">Add</button></div>';
+  <div class="mt-3 flex gap-2"><input class="flex-1 rounded-xl border border-slate-300 px-3 py-2" placeholder="'+escapeHtml(placeholder)+'" /><button class="btn btn-secondary" data-add="1">Add</button></div>';
 }
 
 function bindListEditors(root){
@@ -1028,9 +1018,9 @@ function openResourcesEditor(){
     + '  </div>'
     + '  <div class="p-4 border-t border-slate-200 flex items-center justify-end gap-2">'
     + '    <button type="button" data-cancel'
-    + '      class="rounded-xl px-3 py-2 border border-slate-300 bg-white">Cancel</button>'
+    + '      class="btn btn-outline focus-ring">Cancel</button>'
     + '    <button type="button" data-save'
-    + '      class="rounded-xl px-3 py-2 bg-slate-900 text-white">Save</button>'
+    + '      class="btn btn-secondary focus-ring">Save</button>'
     + '  </div>'
     + '</div>';
 


### PR DESCRIPTION
## Summary
- add Australian green and gold design tokens and restyle header, buttons, tabs, chips, and focus indicators for accessible contrast
- update markup to apply new site-header, button role, and tab classes for consistent theming
- align client-side helpers with the new theme classes for dynamically generated controls and notifications

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8f9ab61a4832481b95c56cc785203