### PR TITLE
Add sequence toggle between default and SA plans

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -36,6 +36,7 @@
         <button id="loadSaPresetBtn" class="btn btn-primary focus-ring" title="Load SA Equal Before the Law?">
           Load SA “Equal Before the Law?”
         </button>
+        <button id="toggleSequenceBtn" class="btn btn-primary focus-ring">Use SA Sequence</button>
         <button id="toggleViewBtn" class="btn btn-primary focus-ring" aria-pressed="false">
           Switch to Dispositions
         </button>
@@ -419,6 +420,7 @@ const DEFAULT_PLAN = {
     lastUpdated: new Date().toISOString().slice(0,10)
   },
   curriculumView: "SA",
+  currentSequence: "default",
   learningIntentions: [
     "Understand how Australia's Constitution structures a federal democracy and enables change (referendums, separation of powers).",
     "Explain how laws are made, interpreted and applied (parliament, courts, rights, responsibilities).",
@@ -633,7 +635,7 @@ const SA_EQUAL_BEFORE_LAW_PRESET = {
       { name: "Final reform proposal (Pairs/Groups)", description: "Persuasive case for change; stakeholders; barriers; evaluation plan.", evidence: "Presentation or paper", criteria: ["Thesis & structure","Use of evidence","Civics terminology","Feasibility & evaluation"] }
     ]
   },
-  sequence: [
+  sequenceSA: [
     { week: 1, title: "Government & Democracy", lessons: [
       { title: "The vibe vs the text of the Constitution", activities: [
         "Big Paper silent conversation on what a constitution should contain.",
@@ -703,22 +705,50 @@ const stateKey = 'yr9-civics-plan-html';
 let plan = loadState();
 let editMode = false;
 
+function preparePlan(data){
+  var base = (data && typeof data === 'object' && !Array.isArray(data)) ? data : deepClone(DEFAULT_PLAN);
+  if(base.currentSequence !== 'sa' && base.currentSequence !== 'default'){
+    base.currentSequence = 'default';
+  }
+  if(!Array.isArray(base.sequence) && Array.isArray(DEFAULT_PLAN.sequence)){
+    base.sequence = deepClone(DEFAULT_PLAN.sequence);
+  }
+  if(!Array.isArray(base.sequenceSA) && SA_EQUAL_BEFORE_LAW_PRESET && Array.isArray(SA_EQUAL_BEFORE_LAW_PRESET.sequenceSA)){
+    base.sequenceSA = deepClone(SA_EQUAL_BEFORE_LAW_PRESET.sequenceSA);
+  }
+  return base;
+}
+
 function loadState(){
   try {
     var raw = localStorage.getItem(stateKey);
-    return raw ? JSON.parse(raw) : deepClone(DEFAULT_PLAN);
+    return preparePlan(raw ? JSON.parse(raw) : deepClone(DEFAULT_PLAN));
   } catch (e) {
-    return deepClone(DEFAULT_PLAN);
+    return preparePlan(deepClone(DEFAULT_PLAN));
   }
 }
 function saveState(){
-  try { localStorage.setItem(stateKey, JSON.stringify(plan)); } catch (e) {}
+  try {
+    plan = preparePlan(plan);
+    localStorage.setItem(stateKey, JSON.stringify(plan));
+  } catch (e) {}
+}
+
+function updateSequenceToggleButton(){
+  var btn = document.getElementById('toggleSequenceBtn');
+  if(!btn){ return; }
+  var hasSaSequence = Array.isArray(plan.sequenceSA);
+  var usingSa = plan.currentSequence === 'sa' && hasSaSequence;
+  btn.textContent = usingSa ? 'Use Default Sequence' : 'Use SA Sequence';
+  btn.setAttribute('aria-pressed', usingSa ? 'true' : 'false');
+  btn.disabled = !hasSaSequence;
 }
 
 function render(){
   document.getElementById('title').textContent = plan.meta.title;
   document.getElementById('subtitle').textContent = plan.meta.subtitle;
   document.getElementById('year').textContent = new Date().getFullYear();
+  updateSequenceToggleButton();
 
   // Unit meta card
   var meta = document.getElementById('unitMeta');
@@ -832,7 +862,18 @@ function renderOverview(root){
 }
 
 function renderSequence(root){
-  root.innerHTML = (plan.sequence || []).map(function(block){
+  var target = root;
+  if(!target){
+    var currentTab = ssGet('yr9-tab', 'Overview');
+    if(currentTab === 'Sequence'){
+      target = document.getElementById('panel');
+    }
+  }
+  if(!target){ return; }
+  var useSa = plan.currentSequence === 'sa' && Array.isArray(plan.sequenceSA);
+  var seq = useSa ? plan.sequenceSA : plan.sequence;
+  var blocks = Array.isArray(seq) ? seq : [];
+  target.innerHTML = blocks.map(function(block){
     var lessonCount = (block.lessons && block.lessons.length) || 0;
     return ''+
     '<div class="rounded-2xl border border-slate-200 p-5 bg-white mb-4">'+
@@ -1069,7 +1110,7 @@ $('#exportBtn').addEventListener('click', function(){
 $('#importInput').addEventListener('change', function(e){
   var files = e.target.files; var f = files && files[0]; if(!f) return;
   var r=new FileReader();
-  r.onload=function(){ try{ plan = JSON.parse(r.result); saveState(); render(); }catch(err){ alert('Invalid JSON'); } };
+  r.onload=function(){ try{ plan = preparePlan(JSON.parse(r.result)); saveState(); render(); }catch(err){ alert('Invalid JSON'); } };
   r.readAsText(f);
 });
 $('#quickEdit').addEventListener('click', function(){
@@ -1082,11 +1123,28 @@ $('#curriculumToggle').addEventListener('click', function(e){
 });
 $('#tabs').addEventListener('click', function(e){ var b=e.target.closest('button'); if(!b) return; selectTab(b.dataset.tab); });
 document.getElementById('bulkResBtn').addEventListener('click', openResourcesEditor);
+var toggleSequenceBtn = document.getElementById('toggleSequenceBtn');
+if(toggleSequenceBtn){
+  toggleSequenceBtn.addEventListener('click', function(){
+    plan = preparePlan(plan);
+    var hasSa = Array.isArray(plan.sequenceSA);
+    var next = plan.currentSequence === 'sa' ? 'default' : 'sa';
+    if(next === 'sa' && !hasSa){
+      updateSequenceToggleButton();
+      return;
+    }
+    plan.currentSequence = next;
+    updateSequenceToggleButton();
+    saveState();
+    renderSequence();
+  });
+}
 $('#loadSaPresetBtn').addEventListener('click', function(){
   var ok = safeConfirm('Replace the current plan with the SA "Equal Before the Law?" preset?');
   if(!ok) return;
   try {
-    plan = deepClone(SA_EQUAL_BEFORE_LAW_PRESET);
+    plan = preparePlan(deepClone(SA_EQUAL_BEFORE_LAW_PRESET));
+    plan.currentSequence = 'sa';
     ssSet('yr9-tab','Overview');
     saveState();
     render();
@@ -1107,6 +1165,8 @@ function runSelfTests(){
   // Existing tests + a few more
   t('plan.meta.title is string', function(){ if(typeof plan.meta.title !== 'string' || !plan.meta.title) throw 'missing title'; });
   t('sequence is array of length >= 1', function(){ if(!Array.isArray(plan.sequence) || plan.sequence.length < 1) throw 'sequence empty'; });
+  t('currentSequence flag valid', function(){ if(['default','sa'].indexOf(plan.currentSequence) === -1) throw 'bad currentSequence'; });
+  t('SA sequence available when selected', function(){ if(plan.currentSequence === 'sa' && (!Array.isArray(plan.sequenceSA) || plan.sequenceSA.length < 1)) throw 'sa sequence missing'; });
   t('assessment.summative has at least 1 task', function(){ if(!plan.assessment || !Array.isArray(plan.assessment.summative) || plan.assessment.summative.length < 1) throw 'no summative'; });
   t('render functions exist', function(){ ['renderOverview','renderSequence','renderAssessment','renderCurriculum'].forEach(function(k){ if(typeof window[k] !== 'function') throw 'missing '+k; }); });
   t('resources entries contain no raw newlines', function(){ (plan.resources||[]).forEach(function(r){ if(/\n/.test(r)) throw 'newline in resources item: '+r; }); });
@@ -1123,7 +1183,7 @@ runSelfTests();
 window.render8Week = function(data){
   if(data && typeof data === 'object' && !Array.isArray(data) && data.meta && data.sequence){
     try {
-      plan = deepClone(data);
+      plan = preparePlan(deepClone(data));
       saveState();
     } catch (err) {
       console.error('Unable to apply provided 8-week data', err);


### PR DESCRIPTION
## Summary
- add a header button that toggles between the default and SA sequences
- persist a `currentSequence` flag alongside both sequence arrays when loading or saving
- render the selected sequence and update related handlers, including the SA preset loader and self-tests

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c9028d0b58832487380aeff0718931