### PR TITLE
Add theme toggle with persistent palette

### DIFF
--- a/css/peo-y9.css
+++ b/css/peo-y9.css
@@ -1,4 +1,4 @@
-:root {
+.theme-green-gold {
   /* Australian Green & Gold (accessible set) */
   --green-600: #006b3f;
   --green-700: #004d2b;
@@ -11,6 +11,21 @@
   --muted: #475569;
   --border: #e2e8f0;
   --ring: #ffcd00;
+}
+
+.theme-aus-flag {
+  /* Australian flag inspired palette */
+  --green-600: #002868;
+  --green-700: #001a5b;
+  --green-300: #3366cc;
+  --gold-500: #bf0a30;
+  --gold-600: #8b081f;
+  --ink: #0f172a;
+  --ink-2: #111827;
+  --bg: #ffffff;
+  --muted: #475569;
+  --border: #d0ddf5;
+  --ring: #bf0a30;
 }
 
 .skip-link {

--- a/index.htm
+++ b/index.htm
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="css/peo-y9.css" />
   <script defer src="js/peo-y9.js"></script>
   <script defer src="js/peo-y9-sequenced.js"></script>
+  <script defer src="js/theme-toggle.js"></script>
   <style>
     @media print {
       header, nav.no-print, .no-print{ display:none !important }
@@ -17,7 +18,7 @@
     }
   </style>
 </head>
-<body class="min-h-screen bg-gradient-to-b from-slate-100 to-slate-200 text-slate-900">
+<body class="theme-green-gold min-h-screen bg-gradient-to-b from-slate-100 to-slate-200 text-slate-900">
   <a class="skip-link" href="#mainContent">Skip to content</a>
   <!-- Top Bar -->
   <header class="site-header sticky top-0 z-10 border-b border-slate-200 backdrop-blur bg-white/70">
@@ -33,6 +34,7 @@
           Import JSON
           <input id="importInput" type="file" accept="application/json" class="hidden" />
         </label>
+        <button id="themeToggle" class="btn btn-outline">Switch Theme</button>
         <button id="loadSaPresetBtn" class="btn btn-primary focus-ring" title="Load SA Equal Before the Law?">
           Load SA “Equal Before the Law?”
         </button>

--- a/js/theme-toggle.js
+++ b/js/theme-toggle.js
@@ -1,0 +1,51 @@
+(function () {
+  const THEMES = {
+    greenGold: 'theme-green-gold',
+    ausFlag: 'theme-aus-flag',
+  };
+
+  const LABELS = {
+    [THEMES.greenGold]: 'Switch to Blue/Red/White',
+    [THEMES.ausFlag]: 'Switch to Green/Gold',
+  };
+
+  const body = document.body;
+  const toggleBtn = document.getElementById('themeToggle');
+
+  if (!body || !toggleBtn) {
+    return;
+  }
+
+  const allThemes = Object.values(THEMES);
+
+  const setTheme = (themeClass) => {
+    allThemes.forEach((theme) => body.classList.remove(theme));
+    body.classList.add(themeClass);
+    try {
+      localStorage.setItem('theme', themeClass);
+    } catch (error) {
+      /* localStorage unavailable */
+    }
+    toggleBtn.textContent = LABELS[themeClass] || 'Switch Theme';
+  };
+
+  let storedTheme;
+  try {
+    storedTheme = localStorage.getItem('theme');
+  } catch (error) {
+    storedTheme = null;
+  }
+
+  const initialTheme = allThemes.includes(storedTheme)
+    ? storedTheme
+    : THEMES.greenGold;
+
+  setTheme(initialTheme);
+
+  toggleBtn.addEventListener('click', () => {
+    const nextTheme = body.classList.contains(THEMES.greenGold)
+      ? THEMES.ausFlag
+      : THEMES.greenGold;
+    setTheme(nextTheme);
+  });
+})();


### PR DESCRIPTION
## Summary
- scope the existing palette under a new `.theme-green-gold` class and add an Australian flag inspired palette
- add a theme toggle control and ensure the body defaults to the green and gold theme
- load a new script that persists the selected theme in localStorage and updates the toggle label accordingly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9087772888324b0c149d6ac130d30