### PR TITLE
Handle sticky header offset for fixed header

### DIFF
--- a/css/peo-y9.css
+++ b/css/peo-y9.css
@@ -11,6 +11,19 @@
   --muted: #475569;
   --border: #e2e8f0;
   --ring: #ffcd00;
+  --header-h: 0px;
+}
+
+body.has-fixed-header {
+  padding-top: var(--header-h);
+}
+
+html {
+  scroll-padding-top: calc(var(--header-h) + 8px);
+}
+
+section[id] {
+  scroll-margin-top: calc(var(--header-h) + 8px);
 }
 
 .skip-link {

--- a/index.htm
+++ b/index.htm
@@ -61,6 +61,29 @@
     </nav>
   </header>
 
+  <script>
+    (function () {
+      const header = document.querySelector('header.site-header');
+      if (!header) return;
+      const root = document.documentElement;
+      const body = document.body;
+
+      const updateHeaderOffset = () => {
+        const height = header.offsetHeight || 0;
+        root.style.setProperty('--header-h', `${height}px`);
+        body.classList.toggle('has-fixed-header', height > 0);
+      };
+
+      updateHeaderOffset();
+      window.addEventListener('resize', updateHeaderOffset);
+
+      if ('ResizeObserver' in window) {
+        const resizeObserver = new ResizeObserver(updateHeaderOffset);
+        resizeObserver.observe(header);
+      }
+    })();
+  </script>
+
   <main id="mainContent" class="max-w-6xl mx-auto p-4">
     <section id="weekView" class="space-y-6">
       <!-- Unit Details Card -->


### PR DESCRIPTION
## Summary
- add a CSS custom property to represent the sticky header height and use it for layout spacing
- inject a script after the header to keep the CSS variable and body class in sync with the header height

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c90a0450088324beb747e1ab1d3a52