### PR TITLE
Streamline header actions

### DIFF
--- a/css/peo-y9.css
+++ b/css/peo-y9.css
@@ -79,6 +79,10 @@ header.site-header nav a:hover {
   transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
+.btn.justify-start {
+  justify-content: flex-start;
+}
+
 .btn-primary {
   background: var(--gold-500);
   color: var(--ink-2);

--- a/index.htm
+++ b/index.htm
@@ -26,18 +26,68 @@
         <h1 id="title" class="text-2xl font-bold tracking-tight">Year 9 Civics: Equal Before the Law</h1>
         <p id="subtitle" class="lead text-sm text-slate-600">How Australia’s Constitution, courts and civic action uphold equality before the law.</p>
       </div>
-      <div class="flex items-center gap-2 no-print">
-        <button id="printBtn" class="btn btn-outline focus-ring" title="Print">Print</button>
-        <button id="exportBtn" class="btn btn-outline focus-ring" title="Export JSON">Export JSON</button>
-        <label class="btn btn-outline focus-ring cursor-pointer" title="Import JSON">
-          Import JSON
-          <input id="importInput" type="file" accept="application/json" class="hidden" />
-        </label>
+      <div class="flex flex-wrap items-center gap-2 no-print">
+        <div class="relative" data-dropdown>
+          <button
+            type="button"
+            id="headerMoreToggle"
+            class="btn btn-secondary focus-ring inline-flex items-center gap-2"
+            aria-haspopup="true"
+            aria-expanded="false"
+            aria-controls="headerMoreMenu"
+          >
+            More
+            <svg
+              class="h-4 w-4"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 10.939l3.71-3.71a.75.75 0 1 1 1.06 1.062l-4.24 4.24a.75.75 0 0 1-1.06 0l-4.24-4.24a.75.75 0 0 1 .02-1.06Z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </button>
+          <div
+            id="headerMoreMenu"
+            class="absolute right-0 mt-2 hidden min-w-[13rem] rounded-2xl border border-slate-200 bg-white p-3 shadow-xl z-10"
+            aria-labelledby="headerMoreToggle"
+          >
+            <div class="flex flex-col gap-2">
+              <button
+                type="button"
+                id="printBtn"
+                class="btn btn-outline focus-ring w-full justify-start text-left"
+                title="Print"
+              >
+                Print
+              </button>
+              <button
+                type="button"
+                id="exportBtn"
+                class="btn btn-outline focus-ring w-full justify-start text-left"
+                title="Export JSON"
+              >
+                Export JSON
+              </button>
+              <label
+                class="btn btn-outline focus-ring w-full justify-start text-left cursor-pointer"
+                title="Import JSON"
+              >
+                Import JSON
+                <input id="importInput" type="file" accept="application/json" class="hidden" />
+              </label>
+            </div>
+          </div>
+        </div>
         <button id="loadSaPresetBtn" class="btn btn-primary focus-ring" title=">Equal Before the Law?">
           Load SA “Equal Before the Law?”
         </button>
-        <button id="toggleSequenceBtn" class="btn btn-primary focus-ring">4-Week SA Curriculum</button>
-        <button id="toggleViewBtn" class="btn btn-primary focus-ring" aria-pressed="false">
+        <button id="toggleSequenceBtn" class="btn btn-secondary focus-ring">4-Week SA Curriculum</button>
+        <button id="toggleViewBtn" class="btn btn-secondary focus-ring" aria-pressed="false">
           Switch to Dispositions
         </button>
         <button id="bulkResBtn"
@@ -1122,6 +1172,47 @@ function openResourcesEditor(){
   // focus textarea
   setTimeout(function(){ ta.focus(); ta.selectionStart = ta.value.length; ta.selectionEnd = ta.value.length; }, 0);
 }
+
+// Header "More" menu behaviour
+(function(){
+  var toggle = document.getElementById('headerMoreToggle');
+  var menu = document.getElementById('headerMoreMenu');
+  if(!toggle || !menu){ return; }
+
+  function setOpen(open){
+    toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    menu.classList.toggle('hidden', !open);
+  }
+
+  function closeMenu(){ setOpen(false); }
+
+  toggle.addEventListener('click', function(event){
+    event.preventDefault();
+    event.stopPropagation();
+    var isOpen = toggle.getAttribute('aria-expanded') === 'true';
+    setOpen(!isOpen);
+  });
+
+  menu.addEventListener('click', function(event){
+    if(event.target.closest('button, label')){
+      closeMenu();
+    }
+  });
+
+  document.addEventListener('click', function(event){
+    if(toggle.contains(event.target) || menu.contains(event.target)){
+      return;
+    }
+    closeMenu();
+  });
+
+  document.addEventListener('keydown', function(event){
+    if(event.key === 'Escape' && toggle.getAttribute('aria-expanded') === 'true'){
+      closeMenu();
+      toggle.focus();
+    }
+  });
+})();
 
 // Events
 $('#printBtn').addEventListener('click', function(){ window.print(); });

--- a/js/view-toggle.js
+++ b/js/view-toggle.js
@@ -10,7 +10,28 @@
     const toggle = $('#toggleViewBtn');
     if (loadBtn && toggle) {
       toggle.className = ''; // reset
-      loadBtn.classList.forEach(c => toggle.classList.add(c));
+      const loadClasses = new Set(loadBtn.classList);
+      loadClasses.forEach(c => {
+        if (c === 'btn-primary') {
+          toggle.classList.add('btn-secondary');
+        } else {
+          toggle.classList.add(c);
+        }
+      });
+      if (!loadClasses.has('btn-primary')) {
+        toggle.classList.add('btn-secondary');
+      }
+      if (!toggle.classList.contains('btn')) {
+        toggle.classList.add('btn');
+      }
+      if (loadClasses.has('focus-ring')) {
+        toggle.classList.add('focus-ring');
+      }
+      if (!toggle.classList.contains('focus-ring')) {
+        toggle.classList.add('focus-ring');
+      }
+    } else if (toggle) {
+      toggle.classList.add('btn', 'btn-secondary', 'focus-ring');
     }
   }
 


### PR DESCRIPTION
## Summary
- Move the print/export/import controls into a secondary "More" dropdown so only the SA preset loader remains primary.
- Downgrade the other header toggles to secondary styling and add the supporting dropdown behavior and alignment tweaks.

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c90b0f9ad48324bbb38741e8cde4c0