### PR TITLE
Add accessible tabs for view switching

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -42,9 +42,41 @@
           Load SA “Equal Before the Law?”
         </button>
         <button id="toggleSequenceBtn" class="btn btn-secondary focus-ring">4-Week SA Curriculum</button>
-        <button id="toggleViewBtn" class="btn btn-secondary focus-ring" aria-pressed="false">
-          Switch to Dispositions
-        </button>
+        <div
+          class="inline-flex flex-wrap gap-1 rounded-2xl border border-slate-300 bg-slate-100 p-1"
+          id="viewToggle"
+          role="tablist"
+          aria-label="View toggle"
+          aria-orientation="horizontal"
+          data-view-tablist
+        >
+          <button
+            type="button"
+            id="viewTab-8week"
+            class="px-3 py-1.5 text-sm font-semibold rounded-xl tab shadow focus-ring"
+            role="tab"
+            aria-selected="true"
+            aria-controls="weekView"
+            tabindex="0"
+            data-view-tab="8week"
+            data-view-target="weekView"
+          >
+            8-Week
+          </button>
+          <button
+            type="button"
+            id="viewTab-dispositions"
+            class="px-3 py-1.5 text-sm rounded-xl tab focus-ring"
+            role="tab"
+            aria-selected="false"
+            aria-controls="dispView"
+            tabindex="-1"
+            data-view-tab="dispositions"
+            data-view-target="dispView"
+          >
+            Dispositions
+          </button>
+        </div>
         <button id="bulkResBtn"
           class="btn btn-secondary focus-ring"
           title="Bulk update Resources">
@@ -90,7 +122,14 @@
   </script>
 
   <main id="main" role="main" class="max-w-6xl mx-auto p-4">
-    <section id="weekView" class="space-y-6">
+    <section
+      id="weekView"
+      class="space-y-6"
+      role="tabpanel"
+      aria-labelledby="viewTab-8week"
+      data-view-panel="8week"
+      tabindex="0"
+    >
       <!-- Unit Details Card -->
       <section class="bg-white/80 backdrop-blur rounded-2xl shadow p-5 border border-slate-200">
         <div class="flex items-start justify-between gap-4">
@@ -193,7 +232,16 @@
       </div>
     </section>
 
-    <section id="dispView" class="space-y-6" hidden aria-hidden="true">
+    <section
+      id="dispView"
+      class="space-y-6"
+      role="tabpanel"
+      aria-labelledby="viewTab-dispositions"
+      data-view-panel="dispositions"
+      hidden
+      aria-hidden="true"
+      tabindex="-1"
+    >
       <section class="bg-white/80 backdrop-blur rounded-2xl shadow p-5 border border-slate-200">
         <div class="flex items-start justify-between gap-4">
           <div>

--- a/js/view-toggle.js
+++ b/js/view-toggle.js
@@ -1,62 +1,68 @@
 (function(){
-  const VIEW_KEY = 'y9_view'; // localStorage key
+  const VIEW_KEY = 'y9_view';
+  const VALID_VIEWS = ['8week', 'dispositions'];
+  const VIEW_SET = new Set(VALID_VIEWS);
+  const DEFAULT_VIEW = '8week';
 
-  const $ = (s, r=document) => r.querySelector(s);
+  const $ = (selector, root = document) => root.querySelector(selector);
+  const $$ = (selector, root = document) => Array.prototype.slice.call(root.querySelectorAll(selector));
 
-  // Try to style-match the existing "Load" button by cloning its classes
-  function styleMatchLoadButton() {
-    const loadBtn = Array.from(document.querySelectorAll('button, .btn, .button'))
-      .find(b => /\bload\b/i.test(b.textContent || ''));
-    const toggle = $('#toggleViewBtn');
-    if (loadBtn && toggle) {
-      toggle.className = ''; // reset
-      loadBtn.classList.forEach(c => toggle.classList.add(c));
+  function normaliseView(value) {
+    return (value || '').toLowerCase();
+  }
+
+  function asView(value) {
+    const view = normaliseView(value);
+    return VIEW_SET.has(view) ? view : '';
+  }
+
+  function getHashTarget() {
+    if (!location.hash) return null;
+    const raw = location.hash.slice(1);
+    if (!raw) return null;
+    let id = raw;
+    try {
+      id = decodeURIComponent(raw);
+    } catch {}
+    if (!id) return null;
+    return document.getElementById(id);
+  }
+
+  function viewFromHash() {
+    const target = getHashTarget();
+    if (!target) return '';
+    const panel = target.closest('[data-view-panel]');
+    if (!panel) return '';
+    return asView(panel.getAttribute('data-view-panel'));
+  }
+
+  function viewFromQuery() {
+    try {
+      const url = new URL(location.href);
+      return asView(url.searchParams.get('view'));
+    } catch {
+      return '';
+    }
+  }
+
+  function viewFromStorage() {
+    try {
+      return asView(localStorage.getItem(VIEW_KEY));
+    } catch {
+      return '';
     }
   }
 
   function getInitialView() {
-    // 1) URL param
+    return viewFromHash() || viewFromQuery() || viewFromStorage() || DEFAULT_VIEW;
+  }
+
+  function focusWithoutScroll(el) {
+    if (!el || typeof el.focus !== 'function') return;
     try {
-      const q = new URL(location.href).searchParams.get('view');
-      if (q === '8week' || q === 'dispositions') return q;
-    } catch {}
-    // 2) Stored
-    try {
-      const saved = localStorage.getItem(VIEW_KEY);
-      if (saved === '8week' || saved === 'dispositions') return saved;
-    } catch {}
-    // 3) Default
-    return '8week';
-  }
-
-  function setSectionVisible(el, on) {
-    if (!el) return;
-    el.hidden = !on;
-    el.setAttribute('aria-hidden', String(!on));
-  }
-
-  async function fetchJSON(path) {
-    const res = await fetch(path, { cache: 'no-store' });
-    if (!res.ok) throw new Error('Failed to fetch ' + path);
-    return res.json();
-  }
-
-  // Optional hooks if you have renderers and JSON paths
-  async function renderIfAvailable(view) {
-    if (view === '8week') {
-      if (typeof window.render8Week === 'function') {
-        if (!window.DATA_8WEEK && window.DATA_8WEEK_PATH) {
-          try { window.DATA_8WEEK = await fetchJSON(window.DATA_8WEEK_PATH); } catch {}
-        }
-        try { window.render8Week(window.DATA_8WEEK); } catch {}
-      }
-    } else {
-      if (typeof window.renderDispositions === 'function') {
-        if (!window.DATA_DISP && window.DATA_DISP_PATH) {
-          try { window.DATA_DISP = await fetchJSON(window.DATA_DISP_PATH); } catch {}
-        }
-        try { window.renderDispositions(window.DATA_DISP); } catch {}
-      }
+      el.focus({ preventScroll: true });
+    } catch {
+      el.focus();
     }
   }
 
@@ -68,39 +74,179 @@
     } catch {}
   }
 
-  async function applyView(view) {
-    const week = $('#weekView');
-    const disp  = $('#dispView');
-    const btn  = $('#toggleViewBtn');
-
-    setSectionVisible(week, view === '8week');
-    setSectionVisible(disp,  view === 'dispositions');
-
-    if (btn) {
-      btn.textContent = (view === '8week') ? 'Switch to Dispositions' : 'Switch to 8-Week Plan';
-      btn.setAttribute('aria-pressed', String(view === 'dispositions'));
-    }
-
-    await renderIfAvailable(view);
+  async function fetchJSON(path) {
+    const res = await fetch(path, { cache: 'no-store' });
+    if (!res.ok) throw new Error('Failed to fetch ' + path);
+    return res.json();
   }
 
-  async function init() {
-    const week = $('#weekView');
-    const disp = $('#dispView');
-    const btn  = $('#toggleViewBtn');
-    if (!week || !disp || !btn) return; // graceful no-op if structure isn’t ready
+  async function renderIfAvailable(view) {
+    if (view === '8week') {
+      if (typeof window.render8Week === 'function') {
+        if (!window.DATA_8WEEK && window.DATA_8WEEK_PATH) {
+          try {
+            window.DATA_8WEEK = await fetchJSON(window.DATA_8WEEK_PATH);
+          } catch {}
+        }
+        try { window.render8Week(window.DATA_8WEEK); } catch {}
+      }
+    } else if (view === 'dispositions') {
+      if (typeof window.renderDispositions === 'function') {
+        if (!window.DATA_DISP && window.DATA_DISP_PATH) {
+          try {
+            window.DATA_DISP = await fetchJSON(window.DATA_DISP_PATH);
+          } catch {}
+        }
+        try { window.renderDispositions(window.DATA_DISP); } catch {}
+      }
+    }
+  }
 
-    styleMatchLoadButton();
+  function init() {
+    const tablist = $('[data-view-tablist]');
+    if (!tablist) return;
 
-    let view = getInitialView();
-    await applyView(view);
+    const tabButtons = $$('[data-view-tab]', tablist);
+    if (!tabButtons.length) return;
 
-    btn.addEventListener('click', async () => {
-      view = (view === '8week') ? 'dispositions' : '8week';
-      try { localStorage.setItem(VIEW_KEY, view); } catch {}
-      setUrlParam(view);
-      await applyView(view);
+    const entries = [];
+    const viewMap = new Map();
+
+    tabButtons.forEach((tab) => {
+      const view = asView(tab.getAttribute('data-view-tab'));
+      if (!view) return;
+
+      const targetId = tab.getAttribute('data-view-target') || tab.getAttribute('aria-controls') || '';
+      let panel = targetId ? document.getElementById(targetId) : null;
+      if (!panel) {
+        panel = document.querySelector(`[data-view-panel="${view}"]`);
+      }
+      if (!panel) return;
+
+      if (!panel.id) {
+        panel.id = `view-panel-${view}`;
+      }
+
+      panel.setAttribute('data-view-panel', view);
+      panel.setAttribute('role', 'tabpanel');
+
+      const tabId = tab.id || `view-tab-${view}`;
+      tab.id = tabId;
+      panel.setAttribute('aria-labelledby', tabId);
+      tab.setAttribute('aria-controls', panel.id);
+      tab.setAttribute('type', tab.getAttribute('type') || 'button');
+
+      entries.push({ view, tab, panel });
+      if (!viewMap.has(view)) {
+        viewMap.set(view, { view, tab, panel });
+      }
     });
+
+    if (!entries.length) return;
+
+    let currentView = '';
+
+    const setTabStates = (activeView) => {
+      entries.forEach(({ view, tab, panel }) => {
+        const isActive = view === activeView;
+        tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+        tab.setAttribute('tabindex', isActive ? '0' : '-1');
+        tab.classList.toggle('shadow', isActive);
+        tab.classList.toggle('font-semibold', isActive);
+        if (panel) {
+          panel.hidden = !isActive;
+          panel.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+          panel.setAttribute('tabindex', isActive ? '0' : '-1');
+        }
+      });
+    };
+
+    const activateView = async (view, options = {}) => {
+      if (!VIEW_SET.has(view)) return;
+      const entry = viewMap.get(view);
+      if (!entry) return;
+      const { tab } = entry;
+
+      if (view === currentView && !options.force) {
+        if (options.focusTab) focusWithoutScroll(tab);
+        return;
+      }
+
+      currentView = view;
+      setTabStates(view);
+
+      if (options.store !== false) {
+        try { localStorage.setItem(VIEW_KEY, view); } catch {}
+      }
+
+      if (options.updateUrl !== false) {
+        setUrlParam(view);
+      }
+
+      if (options.focusTab) {
+        focusWithoutScroll(tab);
+      }
+
+      await renderIfAvailable(view);
+    };
+
+    let initialView = getInitialView();
+    if (!VIEW_SET.has(initialView)) {
+      initialView = DEFAULT_VIEW;
+    }
+    activateView(initialView, { updateUrl: false }).catch(() => {});
+
+    const moveFocus = async (targetEntry) => {
+      if (!targetEntry) return;
+      const { view, tab } = targetEntry;
+      await activateView(view);
+      focusWithoutScroll(tab);
+    };
+
+    entries.forEach((entry, index) => {
+      const { tab } = entry;
+
+      tab.addEventListener('click', async (event) => {
+        event.preventDefault();
+        await activateView(entry.view);
+      });
+
+      tab.addEventListener('keydown', async (event) => {
+        if (event.altKey || event.ctrlKey || event.metaKey) return;
+        const key = event.key || '';
+        const lower = key.toLowerCase();
+        let targetEntry = null;
+
+        if (lower === 'arrowleft' || lower === 'left') {
+          event.preventDefault();
+          const prevIndex = (index - 1 + entries.length) % entries.length;
+          targetEntry = entries[prevIndex];
+        } else if (lower === 'arrowright' || lower === 'right') {
+          event.preventDefault();
+          const nextIndex = (index + 1) % entries.length;
+          targetEntry = entries[nextIndex];
+        } else if (lower === 'home') {
+          event.preventDefault();
+          targetEntry = entries[0];
+        } else if (lower === 'end') {
+          event.preventDefault();
+          targetEntry = entries[entries.length - 1];
+        }
+
+        if (targetEntry) {
+          await moveFocus(targetEntry);
+        }
+      });
+    });
+
+    const syncFromHash = () => {
+      const hashView = viewFromHash();
+      if (hashView && hashView !== currentView) {
+        activateView(hashView).catch(() => {});
+      }
+    };
+
+    window.addEventListener('hashchange', syncFromHash);
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- replace the view toggle button with an accessible tablist for the 8-week and Dispositions sections
- hook the 8-week and Dispositions sections up as tabpanels linked to the new tablist
- rebuild the view toggle script to manage aria attributes, keyboard navigation, and URL/hash-driven activation

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c93d40d6a48324aaa2e46979780fd5