### PR TITLE
Add base green and gold theme tokens

### DIFF
--- a/css/peo-y9.css
+++ b/css/peo-y9.css
@@ -1,16 +1,18 @@
 :root {
   /* Australian Green & Gold (accessible set) */
-  --green-600: #006b3f;
-  --green-700: #004d2b;
+  --green: #006B3F;
+  --green-700: #004D2B;
+  --green-600: var(--green);
   --green-300: #35a56b;
-  --gold-500: #ffcd00;
-  --gold-600: #e6b800;
+  --gold: #FFCD00;
+  --gold-600: #E6B800;
+  --gold-500: var(--gold);
   --ink: #0f172a;
   --ink-2: #1a1a1a;
   --bg: #ffffff;
   --muted: #475569;
   --border: #e2e8f0;
-  --ring: #ffcd00;
+  --ring: var(--gold);
   --header-h: 0px;
 }
 
@@ -42,7 +44,7 @@ section[id] {
 header.site-header {
   background: var(--green-700);
   color: #fff;
-  border-bottom: 3px solid var(--gold-500);
+  border-bottom: 3px solid var(--gold);
 }
 
 header.site-header h1,
@@ -60,7 +62,7 @@ header.site-header nav a {
 }
 
 header.site-header nav a:hover {
-  color: var(--gold-500);
+  color: var(--gold);
   background-color: rgba(255, 255, 255, 0.12);
 }
 
@@ -92,9 +94,9 @@ details.more-menu > summary::-webkit-details-marker {
 }
 
 .btn-primary {
-  background: var(--gold-500);
+  background: var(--gold);
   color: var(--ink-2);
-  border-color: var(--gold-500);
+  border-color: var(--gold);
 }
 
 .btn-primary:hover {
@@ -103,9 +105,9 @@ details.more-menu > summary::-webkit-details-marker {
 }
 
 .btn-secondary {
-  background: var(--green-600);
+  background: var(--green);
   color: #fff;
-  border-color: var(--green-600);
+  border-color: var(--green);
 }
 
 .btn-secondary:hover {
@@ -135,14 +137,14 @@ details.more-menu > summary::-webkit-details-marker {
 }
 
 .tab[aria-selected="true"] {
-  background: var(--gold-500);
+  background: var(--gold);
   color: var(--ink-2);
-  border-color: var(--gold-500);
+  border-color: var(--gold);
 }
 
 .chip {
   background: rgba(255, 205, 0, 0.12);
-  border: 1px solid var(--gold-500);
+  border: 1px solid var(--gold);
   color: var(--ink);
 }
 
@@ -151,7 +153,7 @@ a {
 }
 
 a:hover {
-  color: var(--green-600);
+  color: var(--green);
 }
 
 .card {
@@ -170,7 +172,7 @@ a:hover {
 
 .bg-gold,
 .alert-gold {
-  background: var(--gold-500);
+  background: var(--gold);
   color: var(--ink-2);
 }
 
@@ -507,8 +509,8 @@ a:hover {
 }
 
 .favorite-btn[aria-pressed="true"] {
-  background-color: var(--gold-500);
-  border-color: var(--gold-500);
+  background-color: var(--gold);
+  border-color: var(--gold);
   color: var(--ink-2);
 }
 


### PR DESCRIPTION
## Summary
- add canonical `--green` and `--gold` CSS variables for the PEO theme and alias existing tokens to them
- refactor headers, buttons, chips, alerts, and favorite states to consume the new base tokens for consistent accents

## Testing
- python - <<'PY'
from math import pow

def hex_to_rgb(hex_color):
    hex_color = hex_color.lstrip('#')
    return tuple(int(hex_color[i:i+2], 16)/255 for i in (0, 2, 4))

def linearize(channel):
    if channel <= 0.03928:
        return channel / 12.92
    return ((channel + 0.055) / 1.055) ** 2.4

def luminance(hex_color):
    r, g, b = hex_to_rgb(hex_color)
    r_lin, g_lin, b_lin = map(linearize, (r, g, b))
    return 0.2126 * r_lin + 0.7152 * g_lin + 0.0722 * b_lin

def contrast_ratio(foreground, background):
    lum_fg = luminance(foreground)
    lum_bg = luminance(background)
    lighter = max(lum_fg, lum_bg)
    darker = min(lum_fg, lum_bg)
    return (lighter + 0.05) / (darker + 0.05)

pairs = {
    'white on green': ('#FFFFFF', '#006B3F'),
    'white on green-700': ('#FFFFFF', '#004D2B'),
    'ink-2 on gold': ('#1A1A1A', '#FFCD00'),
    'ink on gold': ('#0F172A', '#FFCD00'),
    'gold on green-700': ('#FFCD00', '#004D2B'),
}

for name, (fg, bg) in pairs.items():
    ratio = contrast_ratio(fg, bg)
    print(f"{name}: {ratio:.2f}:1")
PY

------
https://chatgpt.com/codex/tasks/task_e_68c9408e70808324b0c400a1a7ec5223