### PR TITLE
Add search result summaries and highlights

### DIFF
--- a/css/peo-y9.css
+++ b/css/peo-y9.css
@@ -229,6 +229,11 @@ a:hover {
   margin-bottom: 1.5rem;
 }
 
+.controls .results-summary {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
 .controls input[type="search"],
 .controls select {
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- show a live result count next to the activity and sequence search inputs
- highlight search matches in card titles and descriptive text for both views
- style the new result summary text for consistent presentation

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c94935bbb88324970c67af73aa9508