### PR TITLE
Remove redundant header offset padding

### DIFF
--- a/css/peo-y9.css
+++ b/css/peo-y9.css
@@ -16,10 +16,6 @@
   --header-h: 0px;
 }
 
-body.has-fixed-header {
-  padding-top: var(--header-h);
-}
-
 html {
   scroll-padding-top: calc(var(--header-h) + 8px);
 }

--- a/index.htm
+++ b/index.htm
@@ -115,12 +115,10 @@
       const header = document.querySelector('header.site-header');
       if (!header) return;
       const root = document.documentElement;
-      const body = document.body;
 
       const updateHeaderOffset = () => {
         const height = header.offsetHeight || 0;
         root.style.setProperty('--header-h', `${height}px`);
-        body.classList.toggle('has-fixed-header', height > 0);
       };
 
       updateHeaderOffset();


### PR DESCRIPTION
## Summary
- remove the has-fixed-header padding so the hero stays flush with the top when the sticky header is in view
- keep the header height observer only for updating the CSS variable used by scroll offsets

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c9511393bc83249463abe77f04aae0