### PR TITLE
Center hero title and subtitle

### DIFF
--- a/css/peo-y9.css
+++ b/css/peo-y9.css
@@ -48,6 +48,16 @@ header.site-header .lead {
   color: #fff;
 }
 
+header.site-header .title-group {
+  flex: 1 1 0%;
+  text-align: center;
+}
+
+header.site-header .title-group h1,
+header.site-header .title-group .lead {
+  text-align: inherit;
+}
+
 header.site-header nav {
   background: rgba(0, 77, 43, 0.92);
   border-top: 1px solid rgba(255, 255, 255, 0.12);

--- a/index.htm
+++ b/index.htm
@@ -22,7 +22,7 @@
   <!-- Top Bar -->
   <header role="banner" class="site-header sticky top-0 z-10 border-b border-slate-200 backdrop-blur bg-white/70">
     <div class="max-w-6xl mx-auto px-4 py-4 flex flex-wrap items-center gap-4 justify-between">
-      <div>
+      <div class="title-group">
         <h1 id="title" class="text-2xl font-bold tracking-tight">Year 9 Civics: Equal Before the Law</h1>
         <p id="subtitle" class="lead text-sm text-slate-600">How Australia’s Constitution, courts and civic action uphold equality before the law.</p>
       </div>


### PR DESCRIPTION
## Summary
- add a wrapper class around the hero heading so it can be styled independently
- center align the unit title and subtitle in the site header

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c95423e9c48324a590721a0174a622