### PR TITLE
Add embedded fallback data for PEO Year 9 activities

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -6,6 +6,7 @@
   <title>Year 9 Civics & Citizenship – Unit Plan (Single HTML)</title>
   <script defer src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="css/peo-y9.css" />
+  <script defer src="js/peo-y9-data.js"></script>
   <script defer src="js/peo-y9.js"></script>
   <script defer src="js/peo-y9-sequenced.js"></script>
   <style>

--- a/js/peo-y9-data.js
+++ b/js/peo-y9-data.js
@@ -1,0 +1,622 @@
+(function(){
+  var activitiesData = {
+  "topics": [
+    {
+      "id": "media-literacy",
+      "title": "Media Literacy",
+      "color": "#2463EB",
+      "activities": [
+        {
+          "id": "news-diet-challenge",
+          "title": "News Diet Challenge",
+          "type": [
+            "discussion",
+            "inquiry"
+          ],
+          "duration": "30–45 min",
+          "grouping": "Pairs → Whole class",
+          "objectives": [
+            "Differentiate facts, opinions and bias in news sources",
+            "Reflect on personal news consumption habits"
+          ],
+          "materials": [
+            "Student devices or printed articles",
+            "Reflection sheet (PDF/Doc link)"
+          ],
+          "steps": [
+            "Students list sources they used in the past 48 hours.",
+            "Classify each item: fact / opinion / mixed; identify any bias.",
+            "Pairs swap lists and critique balance (domestic/world, sources, formats).",
+            "Whole-class share: what changed in their ‘news diet’ thinking?"
+          ],
+          "assessment": "Exit ticket: one change they’ll make to improve balance and reliability.",
+          "links": [
+            {
+              "label": "PEO – Year 9 Units (Media)",
+              "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"
+            }
+          ],
+          "tags": [
+            "media",
+            "bias",
+            "source-analysis",
+            "critical-thinking"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "political-parties",
+      "title": "Political Parties",
+      "color": "#16A34A",
+      "activities": [
+        {
+          "id": "frayer-model",
+          "title": "Frayer Model: Party Ideology",
+          "type": [
+            "graphic-organiser",
+            "research"
+          ],
+          "duration": "40–60 min",
+          "grouping": "Small groups",
+          "objectives": [
+            "Define and exemplify key party ideology terms",
+            "Compare similarities and differences across parties"
+          ],
+          "materials": [
+            "Frayer template",
+            "Party websites / fact sheets"
+          ],
+          "steps": [
+            "Assign each group a party/ideology term.",
+            "Complete Frayer (definition, characteristics, examples, non-examples).",
+            "Gallery walk; add ‘two stars and a wish’ feedback to each poster."
+          ],
+          "assessment": "Collect Frayers; assess clarity/accuracy and use of evidence.",
+          "links": [
+            {
+              "label": "PEO – Parties & Government",
+              "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"
+            }
+          ],
+          "tags": [
+            "parties",
+            "ideology",
+            "compare-contrast"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "parliament-law-making",
+      "title": "Parliament & Law-Making",
+      "color": "#DC2626",
+      "activities": [
+        {
+          "id": "bill-simulation",
+          "title": "How a Bill Becomes Law – Simulation",
+          "type": [
+            "simulation",
+            "role-play"
+          ],
+          "duration": "60–90 min",
+          "grouping": "Whole class roles",
+          "objectives": [
+            "Explain the stages of a bill in the federal Parliament",
+            "Experience debate, committee and voting processes"
+          ],
+          "materials": [
+            "Role cards",
+            "Bill summary handout",
+            "Chamber layout"
+          ],
+          "steps": [
+            "Assign roles (Speaker/President, Government/Opposition, Crossbench, Clerks, Whips, Media).",
+            "First/second reading, debate, possible amendments.",
+            "Optional committee stage; third reading; Senate repeat; Royal Assent.",
+            "Debrief: link steps to real-world examples."
+          ],
+          "assessment": "Quick-write: which stage most influences outcomes and why?",
+          "links": [
+            {
+              "label": "PEO – Making Laws",
+              "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"
+            }
+          ],
+          "tags": [
+            "parliament",
+            "bills",
+            "procedure",
+            "debate"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "courts-justice",
+      "title": "Courts & Justice",
+      "color": "#7C3AED",
+      "activities": [
+        {
+          "id": "mock-hearing",
+          "title": "Courtroom Role-Play: How Courts Support Democracy",
+          "type": [
+            "role-play",
+            "case-study"
+          ],
+          "duration": "45–70 min",
+          "grouping": "Small groups → plenary",
+          "objectives": [
+            "Identify roles and processes in Australian courts",
+            "Explain rule of law and judicial independence"
+          ],
+          "materials": [
+            "Case summary",
+            "Role cards",
+            "Verdict sheet"
+          ],
+          "steps": [
+            "Groups stage a short hearing with set roles.",
+            "Observers use a checklist (fairness, due process, evidence usage).",
+            "Compare outcomes across groups; discuss consistency and appeals."
+          ],
+          "assessment": "Checklist + reflection paragraph on fairness and due process.",
+          "links": [
+            {
+              "label": "PEO – Courts & Justice",
+              "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"
+            }
+          ],
+          "tags": [
+            "courts",
+            "rule-of-law",
+            "judicial-independence"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "citizen-participation",
+      "title": "Citizen Participation",
+      "color": "#0EA5E9",
+      "activities": [
+        {
+          "id": "petition-plan",
+          "title": "Petition & Lobby Plan",
+          "type": [
+            "civics-action",
+            "planning"
+          ],
+          "duration": "50–70 min",
+          "grouping": "Teams",
+          "objectives": [
+            "Map an issue, stakeholders, and a lawful action pathway",
+            "Draft a persuasive petition and outreach plan"
+          ],
+          "materials": [
+            "Stakeholder map template",
+            "Petition template"
+          ],
+          "steps": [
+            "Choose a local issue; map stakeholders and decision-makers.",
+            "Draft petition text (clear ask, reasons, evidence).",
+            "Plan lawful outreach (meetings, letters, social media etiquette)."
+          ],
+          "assessment": "Submit a 1-page plan with SMART next steps.",
+          "links": [
+            {
+              "label": "PEO – Participation",
+              "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"
+            }
+          ],
+          "tags": [
+            "participation",
+            "advocacy",
+            "petitions"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "assessment",
+      "title": "Assessment Options",
+      "color": "#F97316",
+      "activities": [
+        {
+          "id": "civics-inquiry-project",
+          "title": "Civics Inquiry: Local Issue Case Study",
+          "type": [
+            "product",
+            "presentation"
+          ],
+          "duration": "Multi-lesson",
+          "grouping": "Individual or pairs",
+          "objectives": [
+            "Investigate a civics issue and present evidence-based recommendations"
+          ],
+          "materials": [
+            "Inquiry guide",
+            "Rubric",
+            "Presentation template"
+          ],
+          "steps": [
+            "Define a guiding question aligned to curriculum content.",
+            "Collect and evaluate sources (reliability, bias).",
+            "Present findings via report, video, podcast, or infographic."
+          ],
+          "assessment": "Rubric aligned to ACARA Year 9 Civics & Citizenship.",
+          "links": [
+            {
+              "label": "PEO – Assessments",
+              "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"
+            }
+          ],
+          "tags": [
+            "assessment",
+            "inquiry",
+            "communication"
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+  var sequencedData = {
+  "sequence": [
+    {
+      "id": "wk1-media-bias-starter",
+      "week": 1,
+      "lessonOrder": 1,
+      "topicId": "media-literacy",
+      "topicTitle": "Media Literacy",
+      "title": "Facts vs Opinion + Bias Starter",
+      "duration": "30–45 min",
+      "grouping": "Pairs → Whole class",
+      "objectives": [
+        "Differentiate fact vs opinion in current news",
+        "Identify bias and techniques in headlines"
+      ],
+      "visibleLearning": {
+        "learningIntentions": "We are learning to distinguish fact, opinion and bias in media.",
+        "successCriteria": [
+          "I can label statements as fact/opinion with reasons",
+          "I can name one bias technique used in a headline"
+        ]
+      },
+      "materials": [
+        "Curated headlines set",
+        "Highlighters",
+        "Exit ticket"
+      ],
+      "steps": [
+        "Hook: two contrasting headlines; quick decide ‘fact/opinion’ and why.",
+        "Pairs annotate a mixed set; highlight claims, evidence, emotive language.",
+        "Whole class: build a mini ‘bias bingo’ list for future spotting."
+      ],
+      "assessment": "Exit ticket: 1 fact claim + 1 opinion claim with justification.",
+      "links": [
+        {
+          "label": "PEO Y9 Units",
+          "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"
+        }
+      ],
+      "tags": [
+        "media",
+        "bias",
+        "critical-thinking"
+      ],
+      "teacherTips": [
+        "Differentiation: provide sentence starters for justifications.",
+        "Formative: cold-call a few pairs to model precise language."
+      ]
+    },
+    {
+      "id": "wk1-news-diet",
+      "week": 1,
+      "lessonOrder": 2,
+      "topicId": "media-literacy",
+      "topicTitle": "Media Literacy",
+      "title": "News Diet Challenge (48-hour)",
+      "duration": "Homework + 20 min debrief",
+      "grouping": "Individual → Pairs",
+      "objectives": [
+        "Audit personal news intake",
+        "Plan one improvement to balance sources"
+      ],
+      "visibleLearning": {
+        "learningIntentions": "We are learning to reflect on the diversity and reliability of our news sources.",
+        "successCriteria": [
+          "I can categorise sources by type and reliability",
+          "I can name one concrete change to improve my news diet"
+        ]
+      },
+      "materials": [
+        "News diet log (template)"
+      ],
+      "steps": [
+        "Students track sources for 48h.",
+        "Pairs swap logs, classify and suggest one improvement.",
+        "Debrief: share common patterns and quick wins."
+      ],
+      "assessment": "Collect logs; check categorisation + improvement suggestion.",
+      "links": [
+        {
+          "label": "PEO Y9 Units – Media",
+          "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"
+        }
+      ],
+      "tags": [
+        "media",
+        "metacognition"
+      ],
+      "teacherTips": [
+        "ELL support: picture icons for source types."
+      ]
+    },
+    {
+      "id": "wk2-parties-frayer",
+      "week": 2,
+      "lessonOrder": 3,
+      "topicId": "political-parties",
+      "topicTitle": "Political Parties",
+      "title": "Frayer Model: Party Ideology",
+      "duration": "45–60 min",
+      "grouping": "Small groups",
+      "objectives": [
+        "Define key ideological terms and apply with examples",
+        "Compare policy positions across parties"
+      ],
+      "visibleLearning": {
+        "learningIntentions": "We are learning to describe and compare party ideologies.",
+        "successCriteria": [
+          "I can complete a Frayer with clear examples/non-examples",
+          "I can contrast two parties on one policy area"
+        ]
+      },
+      "materials": [
+        "Frayer template",
+        "Party fact sheets"
+      ],
+      "steps": [
+        "Assign terms/parties to groups; complete Frayer.",
+        "Gallery walk with ‘two stars and a wish’.",
+        "Class builds a comparative table for one policy (e.g., climate)."
+      ],
+      "assessment": "Collect Frayers; check accuracy and evidence use.",
+      "links": [
+        {
+          "label": "PEO – Parties",
+          "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"
+        }
+      ],
+      "tags": [
+        "ideology",
+        "compare-contrast"
+      ],
+      "teacherTips": [
+        "Offer sentence frames for compare/contrast."
+      ]
+    },
+    {
+      "id": "wk3-bill-simulation",
+      "week": 3,
+      "lessonOrder": 4,
+      "topicId": "parliament-law-making",
+      "topicTitle": "Parliament & Law-Making",
+      "title": "How a Bill Becomes Law – Role-Play",
+      "duration": "60–90 min",
+      "grouping": "Whole class roles",
+      "objectives": [
+        "Explain stages of a bill",
+        "Experience debate, amendment and voting processes"
+      ],
+      "visibleLearning": {
+        "learningIntentions": "We are learning the stages of federal law-making.",
+        "successCriteria": [
+          "I can name the main stages and what happens at each",
+          "I can describe the purpose of amendments and committees"
+        ]
+      },
+      "materials": [
+        "Role cards",
+        "Bill summary",
+        "Chamber layout"
+      ],
+      "steps": [
+        "Assign roles (Speaker/President, Govt/Opposition, Crossbench, Clerks, Whips, Media).",
+        "Run through readings, debate, optional committee, amendments, vote.",
+        "Debrief: map our simulation to the official process."
+      ],
+      "assessment": "Quick-write: which stage most influences outcomes and why?",
+      "links": [
+        {
+          "label": "PEO – Making Laws",
+          "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"
+        }
+      ],
+      "tags": [
+        "parliament",
+        "procedure",
+        "debate"
+      ],
+      "teacherTips": [
+        "Timebox speeches; use traffic-light cards to manage talk time."
+      ]
+    },
+    {
+      "id": "wk4-cards-against-calamity-bridge",
+      "week": 4,
+      "lessonOrder": 5,
+      "topicId": "integration",
+      "topicTitle": "Integration",
+      "title": "Bridge: From Bill Process → Policy Trade-offs (Cards Against Calamity)",
+      "duration": "60 min",
+      "grouping": "Teams",
+      "objectives": [
+        "Connect legislative steps to real policy trade-offs",
+        "Practice stakeholder reasoning and justification"
+      ],
+      "visibleLearning": {
+        "learningIntentions": "We are learning how competing priorities shape policy outcomes.",
+        "successCriteria": [
+          "I can justify a policy choice with stakeholder evidence",
+          "I can explain how an amendment could shift outcomes"
+        ]
+      },
+      "materials": [
+        "Cards Against Calamity game set",
+        "Decision log sheet"
+      ],
+      "steps": [
+        "Teams play a shortened round focused on one issue.",
+        "Each decision logged with ‘who benefits / who loses / evidence’.",
+        "Share-out: connect decisions to potential legislative amendments."
+      ],
+      "assessment": "Collect decision logs; check justified reasoning.",
+      "links": [],
+      "tags": [
+        "simulation",
+        "stakeholders",
+        "reasoning"
+      ],
+      "teacherTips": [
+        "Assign rotating role: ‘evidence officer’ to cite sources."
+      ]
+    },
+    {
+      "id": "wk5-courts-mock-hearing",
+      "week": 5,
+      "lessonOrder": 6,
+      "topicId": "courts-justice",
+      "topicTitle": "Courts & Justice",
+      "title": "Mock Hearing: Courts Support Democracy",
+      "duration": "45–70 min",
+      "grouping": "Small groups → plenary",
+      "objectives": [
+        "Identify court roles and processes",
+        "Explain rule of law and judicial independence"
+      ],
+      "visibleLearning": {
+        "learningIntentions": "We are learning how courts ensure fairness in a democracy.",
+        "successCriteria": [
+          "I can describe roles in a hearing",
+          "I can use the term ‘judicial independence’ correctly"
+        ]
+      },
+      "materials": [
+        "Case summary",
+        "Role cards",
+        "Observer checklist"
+      ],
+      "steps": [
+        "Groups stage a short hearing with set roles.",
+        "Observers complete fairness/due-process checklist.",
+        "Compare outcomes; discuss consistency and appeals."
+      ],
+      "assessment": "Reflection paragraph on fairness and due process.",
+      "links": [
+        {
+          "label": "PEO – Courts & Justice",
+          "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"
+        }
+      ],
+      "tags": [
+        "rule-of-law",
+        "fairness"
+      ],
+      "teacherTips": [
+        "Offer simplified scripts for EAL/D students."
+      ]
+    },
+    {
+      "id": "wk6-citizen-petition-plan",
+      "week": 6,
+      "lessonOrder": 7,
+      "topicId": "citizen-participation",
+      "topicTitle": "Citizen Participation",
+      "title": "Petition & Lobby Plan (Local Issue)",
+      "duration": "50–70 min",
+      "grouping": "Teams",
+      "objectives": [
+        "Map an issue, stakeholders and lawful action pathway",
+        "Draft a persuasive petition and outreach plan"
+      ],
+      "visibleLearning": {
+        "learningIntentions": "We are learning to plan a lawful, effective avenue for change.",
+        "successCriteria": [
+          "I can write a clear ‘ask’ with reasons and evidence",
+          "I can identify decision-makers and next steps"
+        ]
+      },
+      "materials": [
+        "Stakeholder map template",
+        "Petition template"
+      ],
+      "steps": [
+        "Choose a local issue; map stakeholders/decision-makers.",
+        "Draft petition text (clear ask, reasons, evidence).",
+        "Plan outreach (meetings/letters/social media etiquette)."
+      ],
+      "assessment": "Submit a 1-page plan with SMART next steps.",
+      "links": [
+        {
+          "label": "PEO – Participation",
+          "url": "https://peo.gov.au/teach-our-parliament/units-of-work/year-9"
+        }
+      ],
+      "tags": [
+        "advocacy",
+        "civics-action"
+      ],
+      "teacherTips": [
+        "Model a sample paragraph using TEAL/PEEL."
+      ]
+    },
+    {
+      "id": "wk7-summative-inquiry",
+      "week": 7,
+      "lessonOrder": 8,
+      "topicId": "assessment",
+      "topicTitle": "Assessment",
+      "title": "Civics Inquiry (Student Choice Product)",
+      "duration": "Multi-lesson",
+      "grouping": "Individual or pairs",
+      "objectives": [
+        "Investigate a civics issue and present evidence-based recommendations"
+      ],
+      "visibleLearning": {
+        "learningIntentions": "We are learning to investigate and communicate a civics issue using evidence.",
+        "successCriteria": [
+          "I can formulate a guiding question",
+          "I can evaluate sources for reliability and bias",
+          "I can present justified recommendations"
+        ]
+      },
+      "materials": [
+        "Inquiry guide",
+        "Rubric",
+        "Presentation templates"
+      ],
+      "steps": [
+        "Define guiding question aligned to content descriptors.",
+        "Collect/evaluate sources; track evidence.",
+        "Present via report, video, podcast, **Minecraft build**, infographic or live talk."
+      ],
+      "assessment": "Rubric aligned to ACARA Y9 Civics & Citizenship.",
+      "links": [],
+      "tags": [
+        "inquiry",
+        "communication",
+        "student-choice"
+      ],
+      "teacherTips": [
+        "Offer conferencing checkpoints; provide exemplars for each mode."
+      ]
+    }
+  ]
+};
+
+  window.__PEO_Y9_ACTIVITIES__ = window.__PEO_Y9_ACTIVITIES__ || activitiesData;
+  window.__PEO_Y9_SEQUENCED__ = window.__PEO_Y9_SEQUENCED__ || sequencedData;
+})();


### PR DESCRIPTION
## Summary
- embed the PEO Year 9 activity and sequenced datasets in a dedicated script so they are available without network access
- update the activities and sequenced JS controllers to fall back to the embedded data if fetching the JSON files fails
- load the new data bundle ahead of the existing scripts via index.htm so the feature always renders

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c955e261b8832497cd3216b168d604