### PR TITLE
Center hero title text

### DIFF
--- a/css/peo-y9.css
+++ b/css/peo-y9.css
@@ -49,13 +49,25 @@ header.site-header .lead {
 }
 
 header.site-header .title-group {
-  flex: 1 1 0%;
+  flex: 1 1 100%;
+  width: 100%;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
 }
 
 header.site-header .title-group h1,
 header.site-header .title-group .lead {
   text-align: inherit;
+}
+
+header.site-header .title-group + .no-print {
+  width: 100%;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
 header.site-header nav {


### PR DESCRIPTION
## Summary
- expand the header title group to span the full width so the hero title and subtitle are centered
- allow the action toolbar to wrap and center beneath the title for consistent alignment

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c95810d80883248e51b06b22b94fb1