### PR TITLE
Adjust header spacing and navigation link

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -22,9 +22,9 @@
   <a class="skip" href="#main">Skip to main content</a>
   <!-- Top Bar -->
   <header role="banner" class="site-header sticky top-0 z-10 border-b border-slate-200 backdrop-blur bg-white/70">
-    <div class="max-w-6xl mx-auto px-4 py-4 flex flex-wrap items-center gap-4 justify-between">
+    <div class="max-w-6xl mx-auto px-2 py-1 flex flex-wrap items-center gap-4 justify-between">
       <div class="title-group">
-        <h1 id="title" class="text-2xl font-bold tracking-tight">Year 9 Civics: Equal Before the Law</h1>
+        <h1 id="title" class="text-xl font-bold tracking-tight">Year 9 Civics: Equal Before the Law</h1>
         <p id="subtitle" class="lead text-sm text-slate-600">How Australia’s Constitution, courts and civic action uphold equality before the law.</p>
       </div>
       <div class="flex items-center gap-2 no-print">
@@ -95,13 +95,17 @@
       </div>
     </div>
     <nav aria-label="Primary" class="no-print border-t border-slate-200 bg-white/60">
-      <div class="max-w-6xl mx-auto px-4 py-2">
+      <div class="max-w-6xl mx-auto px-2 py-1">
         <ul class="flex flex-wrap items-center gap-3 text-sm font-semibold text-slate-700">
           <li>
-            <a class="rounded-lg px-3 py-2 hover:bg-slate-100 focus-ring" href="#peo-y9">PEO Year 9 Activities</a>
-          </li>
-          <li>
-            <a class="rounded-lg px-3 py-2 hover:bg-slate-100 focus-ring" href="#peo-y9-sequenced">PEO Y9 – Sequenced</a>
+            <a
+              class="underline underline-offset-4 decoration-slate-500 hover:decoration-slate-700 focus-ring"
+              href="https://peo.gov.au/understand-our-parliament/your-resources/classroom-activities/year-9/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              PEO Activities Website
+            </a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- reduce header padding and typography to create a smaller banner
- replace the internal navigation items with an external PEO Year 9 activities link

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68c9c8db9900832789f8151c6707c065