### PR TITLE
Ensure ACARA links display in SA sequence plan

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -703,6 +703,15 @@ const SA_EQUAL_BEFORE_LAW_PRESET = {
     Communicating: ["Create evidence-based explanations/arguments (AC9HC9S05)"]
   },
   curriculumLinks: {
+    ACARA: [
+      { code: "AC9HC9K01", text: "Role of the Australian Constitution; federal system; process for constitutional change (referendum)." },
+      { code: "AC9HC9K02", text: "Legislative processes shaping federal policy; influences on policy." },
+      { code: "AC9HC9K03", text: "Court features, jurisdictions; operations of courts/tribunals." },
+      { code: "AC9HC9K04", text: "Roles in trials; rights of accused and victims; access to justice; legal aid." },
+      { code: "AC9HC9K05", text: "How/why groups participate in civic life and global citizenship." },
+      { code: "AC9HC9K06", text: "Influence of media (incl. social media) on identity and attitudes to diversity." },
+      { code: "AC9HC9S01–S05", text: "Skills: questioning/researching; analysis/evaluation; participation/decision-making; communicating." }
+    ],
     SA: [
       { code: "Learning Standard", text: "Investigate systems/issues; analyse perspectives; evaluate participation strategies; communicate with evidence." },
       { code: "Dispositions", text: "Socially conscious; Discerning; Principled." },
@@ -729,7 +738,7 @@ const SA_EQUAL_BEFORE_LAW_PRESET = {
         "Big Paper silent conversation on what a constitution should contain.",
         "PEO: ‘The Australian Constitution’ video; five-finger summaries (separation of powers, division of powers, rule of law, rep/responsible gov, rights).",
         "Compare expectations with the actual text; revisit Big Paper."
-      ], resources: ["PEO: The Australian Constitution (video)", "Facing History: Big Paper strategy"] },
+      ], resources: ["PEO: The Australian Constitution (video)", "Facing History: Big Paper strategy", "YouTube: It's the vibe clip – https://youtu.be/97IiPli_uXw?si=WjyIarunmCGDFryi"] },
       { title: "Policy → Law & referendums", activities: [
         "Map ‘idea → bill → committees → vote → assent’; identify influence points.",
         "Explore referendum double-majority and past outcomes.",


### PR DESCRIPTION
## Summary
- add the ACARA curriculum descriptors to the SA Equal Before the Law preset so the toggle shows both sets of links

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ca1a33af588327ba7aebede522e90e