### PR TITLE
Improve unit details card layout

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -859,18 +859,34 @@ function render(){
       editMetaField('Updated','lastUpdated', plan.meta.lastUpdated)
     ]));
   } else {
+    var dispositionsBadges = plan.dispositions.length
+      ? plan.dispositions.map(function(d){
+          return '<span class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">' + escapeHtml(d.name) + '</span>';
+        }).join('')
+      : '<span class="text-sm text-slate-500">Add dispositions to spotlight focus areas.</span>';
+
     meta.innerHTML =
-      '<div class="grid grid-cols-2 gap-3 text-sm">\
-      <div><span class="font-medium">Duration:</span> ' + escapeHtml(plan.meta.duration) + '</div>\
-      <div><span class="font-medium">Author:</span> ' + escapeHtml(plan.meta.author) + '</div>\
-      <div><span class="font-medium">School:</span> ' + escapeHtml(plan.meta.school) + '</div>\
-      <div><span class="font-medium">Last updated:</span> ' + escapeHtml(plan.meta.lastUpdated) + '</div>\
-      </div>\
-      <div class="text-sm"><span class="font-medium">Dispositions:</span> ' + plan.dispositions.map(function(d){return escapeHtml(d.name);}).join(', ') + '</div>\
-      <div class="mt-2 text-sm"><span class="font-medium">Capabilities:</span> Critical inquiry · Ethical understanding · Intercultural understanding</div>\
-      <div class="mt-3">\
-        <div class="text-sm font-medium">Learning Intentions</div>\
-        <ul class="list-disc pl-5 text-sm space-y-1">' + plan.learningIntentions.map(function(li){return '<li>'+escapeHtml(li)+'</li>';}).join('') + '</ul>\
+      '<div class="grid gap-6 lg:grid-cols-[1.2fr_0.8fr] items-start">\
+        <div class="space-y-4">\
+          <div class="grid sm:grid-cols-2 gap-3 text-sm">\
+            <div><span class="font-medium">Duration:</span> ' + escapeHtml(plan.meta.duration) + '</div>\
+            <div><span class="font-medium">Author:</span> ' + escapeHtml(plan.meta.author) + '</div>\
+            <div><span class="font-medium">School:</span> ' + escapeHtml(plan.meta.school) + '</div>\
+            <div><span class="font-medium">Last updated:</span> ' + escapeHtml(plan.meta.lastUpdated) + '</div>\
+          </div>\
+          <div>\
+            <div class="text-xs uppercase tracking-wide text-slate-500">Dispositions focus</div>\
+            <div class="mt-2 flex flex-wrap gap-2">' + dispositionsBadges + '</div>\
+          </div>\
+          <div>\
+            <div class="text-xs uppercase tracking-wide text-slate-500">Capabilities</div>\
+            <p class="mt-1 text-sm text-slate-700">Critical inquiry · Ethical understanding · Intercultural understanding</p>\
+          </div>\
+        </div>\
+        <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4 h-full">\
+          <div class="text-xs uppercase tracking-wide text-slate-500">Learning Intentions</div>\
+          <ul class="mt-3 list-disc pl-5 text-sm space-y-1">' + plan.learningIntentions.map(function(li){return '<li>'+escapeHtml(li)+'</li>';}).join('') + '</ul>\
+        </div>\
       </div>';
   }
 


### PR DESCRIPTION
## Summary
- restructure the unit details card to use a two-column layout with better spacing
- display dispositions as badges, keep capabilities grouped, and highlight learning intentions inside a dedicated panel

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bcaa337708324bca9daefd40a8d30)